### PR TITLE
feat: add token-skew analysis skill with OODA-based methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Expert guidance for Apache Cassandra development and operations.
 | `/cassandra-expert:optimize` | Performance tuning, configuration analysis, JVM settings, compaction strategies |
 | `/cassandra-expert:data-model` | Schema design, partition keys, time-series modeling, query patterns |
 | `/cassandra-expert:expert` | General Cassandra questions, CQL analysis, best practices |
+| `/cassandra-expert:token-skew` | Token ownership skew analysis using correct per-rack metric |
 
 #### Usage Examples
 
@@ -45,6 +46,12 @@ Expert guidance for Apache Cassandra development and operations.
 ```
 /cassandra-expert:data-model Design schema for user activity tracking
 /cassandra-expert:data-model How should I model time-series data with 90-day retention?
+```
+
+**Token Skew - Ownership Analysis**
+```
+/cassandra-expert:token-skew Analyze this nodetool ring output for data imbalance
+/cassandra-expert:token-skew nodetool status shows uneven Owns percentages — is this real?
 ```
 
 **Expert - General Questions**

--- a/plugins/cassandra-expert/.claude-plugin/plugin.json
+++ b/plugins/cassandra-expert/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "cassandra-expert",
   "description": "Expert guidance for Apache Cassandra development, including schema design, query optimization, performance tuning, and operational best practices.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Jon Haddad"
   },
   "repository": "https://github.com/rustyrazorblade/skills",
   "license": "Apache-2.0",
-  "keywords": ["cassandra", "database", "nosql", "cql", "schema", "performance"]
+  "keywords": ["cassandra", "database", "nosql", "cql", "schema", "performance", "token-skew"]
 }

--- a/plugins/cassandra-expert/.claude-plugin/plugin.json
+++ b/plugins/cassandra-expert/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cassandra-expert",
   "description": "Expert guidance for Apache Cassandra development, including schema design, query optimization, performance tuning, and operational best practices.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Jon Haddad"
   },

--- a/plugins/cassandra-expert/references/general/token-skew.md
+++ b/plugins/cassandra-expert/references/general/token-skew.md
@@ -1,28 +1,36 @@
 # Token Ownership Skew — Technical Reference
 
-## Overview
+## Terminology
 
-This document provides the full technical detail behind token ownership skew analysis in Apache Cassandra. It covers the allocator code paths, the distinction between full-ring and per-rack ownership metrics, and tested skew ratios across configurations.
+Throughout this document, these terms have precise, distinct meanings:
+
+- **Allocator hint**: The `allocate_tokens_for_local_replication_factor` setting in `cassandra.yaml`. Controls which token placement algorithm is used at bootstrap. Not a keyspace setting.
+- **Keyspace RF**: The replication factor in a keyspace's DDL. Controls how many replicas exist per partition per DC. Not an allocator setting.
+- **Rack count**: Number of distinct racks in a datacenter.
+
+These three values are independent. A cluster can have allocator hint=3, keyspace RF=2, and rack count=3 — all at the same time, each serving a different purpose.
 
 ## Allocator Code Path
 
 ### Selection Logic
 
-Cassandra's `TokenAllocation.createStrategy()` selects between two allocator implementations based on whether `allocate_tokens_for_local_replication_factor` equals the number of racks in the datacenter:
+Cassandra's `TokenAllocation.createStrategy()` selects between two allocator implementations based on whether the **allocator hint** equals the **rack count**:
 
 ```java
 // TokenAllocation.createStrategy() — from cassandra-all 5.0.2:
-if (numRacks == rf) {
+if (numRacks == allocator_hint) {
     return createStrategy(snitch, dc, joiningNodeRack, replicas=1, groupByRack=false);
     // Creates NoReplicationTokenAllocator
-    // This allocator filters the ring to same-rack tokens only
-    // and places new tokens to balance gaps within that rack
+    // Filters the ring to same-rack tokens only
+    // Places new tokens to balance gaps within that rack
 } else {
     // Creates ReplicationAwareTokenAllocator
-    // This allocator sees ALL tokens across all racks
-    // and optimizes for full-ring primary range balance
+    // Sees ALL tokens across all racks
+    // Optimizes for full-ring primary range balance
 }
 ```
+
+The keyspace RF plays no role in this selection. A node being bootstrapped does not consult any keyspace to decide where to place its tokens.
 
 Source files:
 - `org.apache.cassandra.dht.tokenallocator.TokenAllocation` — allocator selection
@@ -32,40 +40,77 @@ Source files:
 
 ### NoReplicationTokenAllocator Behavior
 
-When `numRacks == rf`:
+When allocator hint == rack count:
 1. Filters the token ring to only tokens belonging to nodes in the joining node's rack
 2. Identifies the largest gap between same-rack tokens
 3. Places the new token at the midpoint of that gap
 4. Repeats for each vnode (`num_tokens` times)
 
-This produces optimal **per-rack** balance because it only cares about same-rack spacing. However, the resulting full-ring primary ranges can look highly unbalanced because new tokens may land right next to tokens from other racks.
+This produces optimal **per-rack** balance because it only cares about same-rack spacing. The resulting full-ring primary ranges can look highly unbalanced because new tokens may land right next to tokens from other racks.
 
 ### ReplicationAwareTokenAllocator Behavior
 
-When `numRacks != rf`:
+When allocator hint != rack count:
 1. Sees ALL tokens from all racks
 2. Computes replica ownership considering the full replication strategy
 3. Places tokens to minimize full-ring ownership variance
 
 This produces better full-ring balance but can place same-rack nodes unevenly around the ring, leading to worse per-rack balance.
 
+## Two-Phase Analysis Framework
+
+Token skew analysis must separate two independent concerns:
+
+### Phase 1: Token Distribution Quality
+
+**Question**: Did the allocator place tokens well?
+
+**Metric selection**: Based on allocator hint vs rack count (NOT keyspace RF vs rack count).
+
+| Condition | Metric | Why |
+|---|---|---|
+| Allocator hint == rack count | Per-rack ownership | NoReplicationTokenAllocator was used; it optimized per-rack balance |
+| Allocator hint != rack count | Full-ring ownership | ReplicationAwareTokenAllocator was used; it optimized full-ring balance |
+
+**Expected results** (allocator hint == rack count, num_tokens=4): ~1.20-1.25x per-rack skew, stable across cluster sizes.
+
+### Phase 2: Data Distribution Skew
+
+**Question**: How much data does each node actually store for a given keyspace?
+
+This depends on both the token positions (from Phase 1) AND the keyspace RF. Different keyspaces on the same cluster can have different data skew.
+
+**Method**: Simulate NTS replica placement at the keyspace's RF. For each primary range, walk clockwise picking one node per rack until RF replicas are collected. Sum per-node across all ranges where the node holds a replica.
+
+**Validation**: Compare computed ownership against actual disk Load from `nodetool status`.
+
+### Why Separation Matters
+
+A cluster can have:
+- Perfect token placement (1.20x per-rack) but significant data skew (1.85x) because the keyspace RF differs from the allocator hint
+- Terrible token placement (4.67x per-rack in one rack) but dampened data skew (3.31x at RF=2) because NTS replica flow smooths the imbalance across racks
+
+Mixing these two analyses leads to incorrect conclusions about root cause and incorrect remediation.
+
 ## The Per-Rack vs Full-Ring Distinction
 
 ### Mathematical Foundation
 
-With NetworkTopologyStrategy (NTS), RF=3, and 3 racks, every partition is replicated to all 3 racks. The replica placement algorithm walks clockwise from the partition's token and selects the first node encountered from each rack.
+With NTS, when a keyspace has RF == rack count (e.g., RF=3 with 3 racks), every partition is replicated to all 3 racks. A node's data within its rack is determined by the gap between it and the next same-rack node — cross-rack tokens in between are irrelevant.
 
-For a given rack (say rack-a), a partition is stored on whichever rack-a node is the first rack-a node clockwise from the partition's token. This means a rack-a node's data ownership equals the total of all gaps between it and the preceding rack-a node(s) — cross-rack tokens in between are irrelevant.
+When a keyspace has RF != rack count (e.g., RF=2 with 3 racks), each partition only hits 2 of 3 racks. The data each node stores depends on a more complex calculation involving both its primary ranges and replica ranges inherited from other-rack primaries.
 
-### Traced Example: Why Near-Collisions are Cosmetic
+**Key distinction**: The per-rack metric evaluates token placement quality (Phase 1). The NTS simulation at a specific RF evaluates data distribution (Phase 2). These answer different questions.
 
-6 nodes, 2 per rack, RF=3, with a near-collision:
+### Traced Example: Why Cross-Rack Near-Collisions are Cosmetic
+
+6 nodes, 2 per rack, allocator hint=3, rack count=3, with a near-collision:
 
 ```text
 Ring positions:
   a0: 0      (rack-a)
   b0: 17     (rack-b)
-  a1: 18     (rack-a)  <-- near-collision with b0
+  a1: 18     (rack-a)  <-- near-collision with b0 (CROSS-RACK)
   c0: 33     (rack-c)
   b1: 67     (rack-b)
   c1: 83     (rack-c)
@@ -84,55 +129,52 @@ Ring positions:
 
 Full-ring ratio: 34/1 = 34x. Looks catastrophic.
 
-**Per-rack ownership (tracing NTS replica placement):**
+**Per-rack ownership (correct metric for Phase 1):**
 
 Rack-a tokens: a0 at 0, a1 at 18. Gap a0->a1 = 18, gap a1->a0 = 82.
 
-| Partition token | Walk clockwise for rack-a | Rack-a node |
-|-----------------|---------------------------|-------------|
-| 1-18            | a1 is first rack-a node   | a1          |
-| 19-100 (wrapping to 0) | a0 is first rack-a node | a0 |
+| Partition token | First rack-a node clockwise | Rack-a node |
+|---|---|---|
+| 1-18 | a1 | a1 |
+| 19-100 (wrapping to 0) | a0 | a0 |
 
-Per-rack ownership:
-- a1: 18% of all data
-- a0: 82% of all data
-- Per-rack ratio: 82/18 = 4.6x (in this simplified 1-token example)
+Per-rack ownership: a1 = 18%, a0 = 82%. Per-rack ratio: 4.6x (in this simplified 1-token example). With `num_tokens: 4`, bad placements average out, producing a stable ~1.25x ratio.
 
-With `num_tokens: 4`, each node has 4 tokens and the bad placements average out, producing a stable ~1.25x ratio.
+The cross-rack near-collision (b0 at 17, a1 at 18) is cosmetic — it makes the full-ring numbers look terrible but has zero effect on per-rack balance.
 
-### RF=3 (NoReplication) vs RF=2 (ReplicationAware): Side-by-Side
+### Side-by-Side: Allocator Hint = 3 vs 2
 
 Starting with 3 seed nodes evenly spaced, adding a 4th node to rack-a:
 
 ```text
 Seed ring: a0 at 0, b0 at 33, c0 at 66
 
-allocate_tokens = 3 (NoReplication):
+allocator hint = 3 (NoReplicationTokenAllocator):
   Sees only rack-a: [a0 at 0]
   Biggest gap: 0 -> 0 (full ring = 100)
   Places a1 at midpoint: position 50
-  Rack-a spacing: a0(0) -> a1(50) = 50, a1(50) -> a0(0) = 50
-  Per-rack ratio: 1.0x (perfect!)
+  Rack-a spacing: a0(0)->a1(50) = 50, a1(50)->a0(0) = 50
+  Per-rack ratio: 1.0x (perfect)
 
-allocate_tokens = 2 (ReplicationAware):
+allocator hint = 2 (ReplicationAwareTokenAllocator):
   Sees all racks: [a0:0, b0:33, c0:66]
-  Biggest full-ring gap: c0(66) -> a0(0) = 34
+  Biggest full-ring gap: c0(66)->a0(0) = 34
   Places a1 at position 83 (midpoint of biggest gap)
-  Rack-a spacing: a0(0) -> a1(83) = 83, a1(83) -> a0(0) = 17
-  Per-rack ratio: 83/17 = 4.9x (terrible!)
+  Rack-a spacing: a0(0)->a1(83) = 83, a1(83)->a0(0) = 17
+  Per-rack ratio: 83/17 = 4.9x (terrible)
 
 With num_tokens=4, these average out to:
-  NoReplication:    ~1.25x per-rack
-  ReplicationAware: ~1.46x to 2.44x per-rack
+  allocator hint=3: ~1.25x per-rack
+  allocator hint=2: ~1.46x to 2.44x per-rack
 ```
 
 ## Tested Skew Ratios
 
-Measured on Cassandra 5.0 clusters across multiple configurations. Results are deterministic across runs. The recommended `num_tokens` values are 1 or 4 (see `vnodes.md`); `num_tokens: 3` is included for comparison only.
+Measured on Cassandra 5.0.6 clusters. The "Hint" column is the allocator hint, NOT a keyspace RF. Results are deterministic across runs.
 
 ### Full Matrix: Full-Ring vs Per-Rack
 
-| num_tokens | RF | Allocator | Metric | 6 nodes | 9 nodes | 12 nodes | 18 nodes |
+| num_tokens | Hint | Allocator | Metric | 6 nodes | 9 nodes | 12 nodes | 18 nodes |
 |---|---|---|---|---|---|---|---|
 | 4 | 3 | NoReplication | full-ring | 2.00x | 3.00x | 2.00x | 5.00x |
 | 4 | 3 | NoReplication | per-rack | 1.25x | 1.25x | 1.25x | 1.20x |
@@ -145,7 +187,9 @@ Measured on Cassandra 5.0 clusters across multiple configurations. Results are d
 
 ### Effect of Pre-computed Seed Tokens
 
-Some operators (e.g., cass-operator) pre-compute evenly-spaced `initial_token` values for seed nodes. Whether or not seeds are pre-computed, **per-rack skew for RF=3 is the same** (~1.25x with `num_tokens: 4`). Pre-computed seeds only affect full-ring appearance, not per-rack reality.
+Some operators (e.g., cass-operator) pre-compute evenly-spaced `initial_token` values for seed nodes. Whether or not seeds are pre-computed, **per-rack skew with allocator hint=3 and num_tokens=4 is the same** (~1.25x). Pre-computed seeds only affect full-ring appearance, not per-rack reality.
+
+Note: Pre-computed tokens that evenly divide the full ring without considering per-rack balance can produce high per-rack skew (3-4x) even though the full-ring distribution looks perfect. Token computation must optimize for per-rack balance when the allocator hint == rack count.
 
 ## Near-Collision Analysis
 
@@ -153,23 +197,21 @@ Some operators (e.g., cass-operator) pre-compute evenly-spaced `initial_token` v
 
 A near-collision occurs when two tokens from different nodes are extremely close on the ring. On the full 2^64 Murmur3 token range, gaps can be extremely small (single digits).
 
-Whether near-collisions occur depends on the seed token starting offset, which varies per cluster. They are not inherent to the allocator algorithm itself.
-
 ### Impact Classification
 
-| Type | Example | Impact when RF = rack count |
-|------|---------|---------------------------|
-| Cross-rack | rack-a and rack-b tokens nearly adjacent | None (cosmetic) |
-| Same-rack | Two same-rack tokens nearly adjacent | Real — one node stores almost nothing for that vnode |
+| Type | Description | Impact on token placement (Phase 1) |
+|---|---|---|
+| Cross-rack | Tokens from different racks nearly adjacent | Cosmetic when allocator hint == rack count |
+| Same-rack | Tokens from same rack nearly adjacent | Real problem — causes per-rack imbalance |
 
-With `num_tokens: 4`, even a same-rack near-collision on one vnode is diluted by the other 3 vnodes. The overall per-rack skew remains bounded.
+**Cascading effect**: A same-rack near-collision doesn't just affect the 2 colliding nodes. It displaces ownership across the entire rack, potentially pushing many nodes outside the normal range.
 
 ## The num_tokens Averaging Effect
 
-With `num_tokens: 4`, each node has 4 tokens around the ring. If one token lands in a suboptimal position, the other 3 tokens still contribute normal-sized gaps. A node's total data ownership is the sum across all its token ranges.
+With `num_tokens: 4`, each node has 4 tokens around the ring. If one token lands in a suboptimal position, the other 3 tokens still contribute normal-sized gaps. A node's total ownership is the sum across all its token ranges.
 
 - With `num_tokens: 1`: A single bad placement is catastrophic — no averaging.
-- With `num_tokens: 4`: Bad placements are diluted. Per-rack skew stabilizes at 1.25x for RF=3.
+- With `num_tokens: 4`: Bad placements are diluted. Per-rack skew stabilizes at 1.25x.
 - With `num_tokens: 16+`: More averaging, but the operational costs (streaming, neighbors) far outweigh the marginal balance improvement.
 
 ## References

--- a/plugins/cassandra-expert/references/general/token-skew.md
+++ b/plugins/cassandra-expert/references/general/token-skew.md
@@ -12,31 +12,116 @@ These three values are independent. A cluster can have allocator hint=3, keyspac
 
 ## Allocator Code Path
 
-### Selection Logic
+### Selection Logic (Cassandra 5.0)
 
-Cassandra's `TokenAllocation.createStrategy()` selects between two allocator implementations based on whether the **allocator hint** equals the **rack count**:
+The allocator selection happens across multiple classes. The code path below is traced from `cassandra-5.0` branch with source links.
+
+**Step 1** — [`BootStrapper.getBootstrapTokens()`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/BootStrapper.java#L157-L180) reads the allocator hint from cassandra.yaml and dispatches:
 
 ```java
-// TokenAllocation.createStrategy() — from cassandra-all 5.0.2:
-if (numRacks == allocator_hint) {
-    return createStrategy(snitch, dc, joiningNodeRack, replicas=1, groupByRack=false);
-    // Creates NoReplicationTokenAllocator
-    // Filters the ring to same-rack tokens only
-    // Places new tokens to balance gaps within that rack
-} else {
-    // Creates ReplicationAwareTokenAllocator
-    // Sees ALL tokens across all racks
-    // Optimizes for full-ring primary range balance
+Integer allocationLocalRf = DatabaseDescriptor.getAllocateTokensForLocalRf();
+// reads allocate_tokens_for_local_replication_factor from cassandra.yaml
+
+if (initialTokens.size() > 0)
+    return getSpecifiedTokens(...);           // user-provided tokens, skip allocator
+if (allocationKeyspace != null)
+    return allocateTokens(metadata, address, allocationKeyspace, ...);  // keyspace-based
+if (allocationLocalRf != null)
+    return allocateTokens(metadata, address, allocationLocalRf, ...);   // hint-based path
+```
+
+With `allocate_tokens_for_local_replication_factor: 3`, this calls `allocateTokens(metadata, address, 3, ...)`.
+
+**Step 2** — [`BootStrapper.allocateTokens(metadata, address, rf=3, ...)`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/BootStrapper.java#L227-L240) passes the integer straight through:
+
+```java
+Collection<Token> tokens = TokenAllocation.allocateTokens(metadata, rf, address, numTokens);
+```
+
+**Step 3** — [`TokenAllocation.create(snitch, tokenMetadata, replicas=3, numTokens)`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java#L68-L74) creates a **fake NTS strategy** from the hint value. No real keyspace is consulted:
+
+```java
+HashMap<String, String> options = new HashMap<>();
+options.put(snitch.getLocalDatacenter(), Integer.toString(replicas)); // "3"
+NetworkTopologyStrategy fakeReplicationStrategy =
+    new NetworkTopologyStrategy(null, tokenMetadata, snitch, options);
+```
+
+**Step 4** — [`TokenAllocation.createStrategy(tokenMetadata, NTS, dc, rack)`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java#L192-L222) compares the hint (via the fake NTS) against the actual rack count and creates a `StrategyAdapter`:
+
+```java
+int replicas = strategy.getReplicationFactor(dc).allReplicas; // 3 (from fake NTS = the hint)
+int racks = topology.getDatacenterRacks().get(dc).asMap().size(); // 3 (actual topology)
+
+if (replicas <= 1) {
+    return createStrategy(snitch, dc, null, 1, false);
+}
+else if (racks == replicas) {      // 3 == 3 → TRUE
+    // Per-rack allocation ring, replicas set to 1
+    return createStrategy(snitch, dc, rack, 1, false);
+}
+else if (racks > replicas) {
+    // Full DC ring, grouped by rack
+    return createStrategy(snitch, dc, null, replicas, true);
 }
 ```
 
-The keyspace RF plays no role in this selection. A node being bootstrapped does not consult any keyspace to decide where to place its tokens.
+The `racks == replicas` branch creates a [`StrategyAdapter`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java#L225-L244) where:
+- `replicas()` returns **1** (not the original hint value)
+- `inAllocationRing(other)` returns true only if `other` is in **the same rack** as the joining node
+- `getGroup(unit)` returns the unit itself (no rack grouping — each node is independent)
 
-Source files:
-- `org.apache.cassandra.dht.tokenallocator.TokenAllocation` — allocator selection
-- `org.apache.cassandra.dht.tokenallocator.NoReplicationTokenAllocator` — per-rack balancing
-- `org.apache.cassandra.dht.tokenallocator.ReplicationAwareTokenAllocator` — full-ring balancing
-- `org.apache.cassandra.locator.NetworkTopologyStrategy` — replica placement (walks clockwise, picks one node per rack)
+**Step 5** — [`StrategyAdapter.createAllocator()`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java#L131-L140) builds the token map, filtering by `inAllocationRing()`:
+
+```java
+NavigableMap<Token, InetAddressAndPort> sortedTokens = new TreeMap<>();
+for (Map.Entry<Token, InetAddressAndPort> en :
+     tokenMetadata.getNormalAndBootstrappingTokenToEndpointMap().entrySet())
+{
+    if (inAllocationRing(en.getValue()))    // only same-rack nodes pass
+        sortedTokens.put(en.getKey(), en.getValue());
+}
+return TokenAllocatorFactory.createTokenAllocator(sortedTokens, this, ...);
+```
+
+**Step 6** — [`TokenAllocatorFactory.createTokenAllocator()`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorFactory.java#L36-L50) selects the allocator implementation based on the adapter:
+
+```java
+if (strategy.replicas() == 1)    // TRUE — set to 1 in Step 4
+    return new NoReplicationTokenAllocator<>(sortedTokens, strategy, partitioner);
+else
+    return new ReplicationAwareTokenAllocator<>(sortedTokens, strategy, partitioner);
+```
+
+The factory has no knowledge of the allocator hint or rack count. It only sees the pre-processed adapter from Step 4.
+
+**Summary of the code path:**
+
+| Step | Class | What happens |
+|---|---|---|
+| 1 | `BootStrapper` | Reads `allocate_tokens_for_local_replication_factor: 3` from yaml |
+| 2 | `BootStrapper` | Passes `rf=3` to `TokenAllocation` |
+| 3 | `TokenAllocation` | Creates fake NTS with RF=3 in local DC (no real keyspace involved) |
+| 4 | `TokenAllocation` | `racks(3) == replicas(3)` → adapter with `replicas()=1`, rack-scoped |
+| 5 | `StrategyAdapter` | Filters token map to same-rack tokens only |
+| 6 | `TokenAllocatorFactory` | `replicas()==1` → `NoReplicationTokenAllocator` on rack-scoped ring |
+
+**End result by allocator hint vs rack count (for NTS):**
+
+| Condition | Step 4 branch | Adapter | Allocator | Scope |
+|---|---|---|---|---|
+| hint == racks | `racks == replicas` | `replicas=1`, rack-scoped | `NoReplicationTokenAllocator` | Same-rack only |
+| hint < racks | `racks > replicas` | `replicas=hint`, groupByRack | `ReplicationAwareTokenAllocator` | Full DC |
+| hint > racks | none | Error | — | — |
+
+The keyspace RF plays no role anywhere in this path. The fake NTS in Step 3 is built solely from the allocator hint.
+
+Source files (all `cassandra-5.0` branch):
+- [`o.a.c.dht.BootStrapper`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/BootStrapper.java) — entry point, reads config
+- [`o.a.c.dht.tokenallocator.TokenAllocation`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocation.java) — fake NTS, hint/rack comparison, adapter creation
+- [`o.a.c.dht.tokenallocator.TokenAllocatorFactory`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/tokenallocator/TokenAllocatorFactory.java) — allocator instantiation
+- [`o.a.c.dht.tokenallocator.NoReplicationTokenAllocator`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/tokenallocator/NoReplicationTokenAllocator.java) — per-rack balancing
+- [`o.a.c.dht.tokenallocator.ReplicationAwareTokenAllocator`](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/dht/tokenallocator/ReplicationAwareTokenAllocator.java) — full-ring balancing
 
 ### NoReplicationTokenAllocator Behavior
 

--- a/plugins/cassandra-expert/references/general/token-skew.md
+++ b/plugins/cassandra-expert/references/general/token-skew.md
@@ -1,0 +1,178 @@
+# Token Ownership Skew — Technical Reference
+
+## Overview
+
+This document provides the full technical detail behind token ownership skew analysis in Apache Cassandra. It covers the allocator code paths, the distinction between full-ring and per-rack ownership metrics, and tested skew ratios across configurations.
+
+## Allocator Code Path
+
+### Selection Logic
+
+Cassandra's `TokenAllocation.createStrategy()` selects between two allocator implementations based on whether `allocate_tokens_for_local_replication_factor` equals the number of racks in the datacenter:
+
+```java
+// TokenAllocation.createStrategy() — from cassandra-all 5.0.2:
+if (numRacks == rf) {
+    return createStrategy(snitch, dc, joiningNodeRack, replicas=1, groupByRack=false);
+    // Creates NoReplicationTokenAllocator
+    // This allocator filters the ring to same-rack tokens only
+    // and places new tokens to balance gaps within that rack
+} else {
+    // Creates ReplicationAwareTokenAllocator
+    // This allocator sees ALL tokens across all racks
+    // and optimizes for full-ring primary range balance
+}
+```
+
+Source files:
+- `org.apache.cassandra.dht.tokenallocator.TokenAllocation` — allocator selection
+- `org.apache.cassandra.dht.tokenallocator.NoReplicationTokenAllocator` — per-rack balancing
+- `org.apache.cassandra.dht.tokenallocator.ReplicationAwareTokenAllocator` — full-ring balancing
+- `org.apache.cassandra.locator.NetworkTopologyStrategy` — replica placement (walks clockwise, picks one node per rack)
+
+### NoReplicationTokenAllocator Behavior
+
+When `numRacks == rf`:
+1. Filters the token ring to only tokens belonging to nodes in the joining node's rack
+2. Identifies the largest gap between same-rack tokens
+3. Places the new token at the midpoint of that gap
+4. Repeats for each vnode (`num_tokens` times)
+
+This produces optimal **per-rack** balance because it only cares about same-rack spacing. However, the resulting full-ring primary ranges can look highly unbalanced because new tokens may land right next to tokens from other racks.
+
+### ReplicationAwareTokenAllocator Behavior
+
+When `numRacks != rf`:
+1. Sees ALL tokens from all racks
+2. Computes replica ownership considering the full replication strategy
+3. Places tokens to minimize full-ring ownership variance
+
+This produces better full-ring balance but can place same-rack nodes unevenly around the ring, leading to worse per-rack balance.
+
+## The Per-Rack vs Full-Ring Distinction
+
+### Mathematical Foundation
+
+With NetworkTopologyStrategy (NTS), RF=3, and 3 racks, every partition is replicated to all 3 racks. The replica placement algorithm walks clockwise from the partition's token and selects the first node encountered from each rack.
+
+For a given rack (say rack-a), a partition is stored on whichever rack-a node is the first rack-a node clockwise from the partition's token. This means a rack-a node's data ownership equals the total of all gaps between it and the preceding rack-a node(s) — cross-rack tokens in between are irrelevant.
+
+### Traced Example: Why Near-Collisions are Cosmetic
+
+6 nodes, 2 per rack, RF=3, with a near-collision:
+
+```text
+Ring positions:
+  a0: 0      (rack-a)
+  b0: 17     (rack-b)
+  a1: 18     (rack-a)  <-- near-collision with b0
+  c0: 33     (rack-c)
+  b1: 67     (rack-b)
+  c1: 83     (rack-c)
+```
+
+**Full-ring primary ranges:**
+
+| Node | Gap | Full-ring % |
+|------|-----|-------------|
+| a0   | c1(83) to a0(0) = 17 | 17% |
+| b0   | a0(0) to b0(17) = 17 | 17% |
+| a1   | b0(17) to a1(18) = 1 | 1% |
+| c0   | a1(18) to c0(33) = 15 | 15% |
+| b1   | c0(33) to b1(67) = 34 | 34% |
+| c1   | b1(67) to c1(83) = 16 | 16% |
+
+Full-ring ratio: 34/1 = 34x. Looks catastrophic.
+
+**Per-rack ownership (tracing NTS replica placement):**
+
+Rack-a tokens: a0 at 0, a1 at 18. Gap a0->a1 = 18, gap a1->a0 = 82.
+
+| Partition token | Walk clockwise for rack-a | Rack-a node |
+|-----------------|---------------------------|-------------|
+| 1-18            | a1 is first rack-a node   | a1          |
+| 19-100 (wrapping to 0) | a0 is first rack-a node | a0 |
+
+Per-rack ownership:
+- a1: 18% of all data
+- a0: 82% of all data
+- Per-rack ratio: 82/18 = 4.6x (in this simplified 1-token example)
+
+With `num_tokens: 4`, each node has 4 tokens and the bad placements average out, producing a stable ~1.25x ratio.
+
+### RF=3 (NoReplication) vs RF=2 (ReplicationAware): Side-by-Side
+
+Starting with 3 seed nodes evenly spaced, adding a 4th node to rack-a:
+
+```text
+Seed ring: a0 at 0, b0 at 33, c0 at 66
+
+allocate_tokens = 3 (NoReplication):
+  Sees only rack-a: [a0 at 0]
+  Biggest gap: 0 -> 0 (full ring = 100)
+  Places a1 at midpoint: position 50
+  Rack-a spacing: a0(0) -> a1(50) = 50, a1(50) -> a0(0) = 50
+  Per-rack ratio: 1.0x (perfect!)
+
+allocate_tokens = 2 (ReplicationAware):
+  Sees all racks: [a0:0, b0:33, c0:66]
+  Biggest full-ring gap: c0(66) -> a0(0) = 34
+  Places a1 at position 83 (midpoint of biggest gap)
+  Rack-a spacing: a0(0) -> a1(83) = 83, a1(83) -> a0(0) = 17
+  Per-rack ratio: 83/17 = 4.9x (terrible!)
+
+With num_tokens=4, these average out to:
+  NoReplication:    ~1.25x per-rack
+  ReplicationAware: ~1.46x to 2.44x per-rack
+```
+
+## Tested Skew Ratios
+
+Measured on Cassandra 5.0 clusters across multiple configurations. Results are deterministic across runs. The recommended `num_tokens` values are 1 or 4 (see `vnodes.md`); `num_tokens: 3` is included for comparison only.
+
+### Full Matrix: Full-Ring vs Per-Rack
+
+| num_tokens | RF | Allocator | Metric | 6 nodes | 9 nodes | 12 nodes | 18 nodes |
+|---|---|---|---|---|---|---|---|
+| 4 | 3 | NoReplication | full-ring | 2.00x | 3.00x | 2.00x | 5.00x |
+| 4 | 3 | NoReplication | per-rack | 1.25x | 1.25x | 1.25x | 1.20x |
+| 3 | 3 | NoReplication | full-ring | 2.50x | 2.75x | 2.83x | 2.99x |
+| 3 | 3 | NoReplication | per-rack | 1.33x | 1.33x | 1.33x | 1.31x |
+| 4 | 2 | ReplicationAware | full-ring | 1.33x | 2.00x | 1.50x | 1.60x |
+| 4 | 2 | ReplicationAware | per-rack | 1.46x | 1.87x | 2.00x | 1.62x |
+| 3 | 2 | ReplicationAware | full-ring | 1.67x | 2.00x | 1.67x | 2.00x |
+| 3 | 2 | ReplicationAware | per-rack | 2.43x | 1.54x | 2.00x | 2.44x |
+
+### Effect of Pre-computed Seed Tokens
+
+Some operators (e.g., cass-operator) pre-compute evenly-spaced `initial_token` values for seed nodes. Whether or not seeds are pre-computed, **per-rack skew for RF=3 is the same** (~1.25x with `num_tokens: 4`). Pre-computed seeds only affect full-ring appearance, not per-rack reality.
+
+## Near-Collision Analysis
+
+### Definition
+
+A near-collision occurs when two tokens from different nodes are extremely close on the ring. On the full 2^64 Murmur3 token range, gaps can be extremely small (single digits).
+
+Whether near-collisions occur depends on the seed token starting offset, which varies per cluster. They are not inherent to the allocator algorithm itself.
+
+### Impact Classification
+
+| Type | Example | Impact when RF = rack count |
+|------|---------|---------------------------|
+| Cross-rack | rack-a and rack-b tokens nearly adjacent | None (cosmetic) |
+| Same-rack | Two same-rack tokens nearly adjacent | Real — one node stores almost nothing for that vnode |
+
+With `num_tokens: 4`, even a same-rack near-collision on one vnode is diluted by the other 3 vnodes. The overall per-rack skew remains bounded.
+
+## The num_tokens Averaging Effect
+
+With `num_tokens: 4`, each node has 4 tokens around the ring. If one token lands in a suboptimal position, the other 3 tokens still contribute normal-sized gaps. A node's total data ownership is the sum across all its token ranges.
+
+- With `num_tokens: 1`: A single bad placement is catastrophic — no averaging.
+- With `num_tokens: 4`: Bad placements are diluted. Per-rack skew stabilizes at 1.25x for RF=3.
+- With `num_tokens: 16+`: More averaging, but the operational costs (streaming, neighbors) far outweigh the marginal balance improvement.
+
+## References
+
+- Cassandra source: `TokenAllocation.java`, `NoReplicationTokenAllocator.java`, `ReplicationAwareTokenAllocator.java`, `NetworkTopologyStrategy.java`
+- vnodes reference: `vnodes.md` (in this directory)

--- a/plugins/cassandra-expert/references/general/vnodes.md
+++ b/plugins/cassandra-expert/references/general/vnodes.md
@@ -91,3 +91,7 @@ This is why getting it right from the start is critical.  Both operations requir
 | 4 | Good balance, automatic distribution | Low |
 | 16 | Legacy clusters only | High, increasing with cluster size |
 | 256 | Never use | Critical |
+
+## Token Skew with vnodes
+
+With `num_tokens: 4` and 3 racks, the token allocator produces a per-rack ownership skew of ~1.25x. This is real but not critical. See `token-skew.md` for detailed analysis of how the allocator places tokens and why full-ring metrics are misleading.

--- a/plugins/cassandra-expert/skills/diagnose/SKILL.md
+++ b/plugins/cassandra-expert/skills/diagnose/SKILL.md
@@ -120,9 +120,12 @@ When diagnosing issues, always compare nodes to identify outliers:
 - Verify JVM settings match workload
 
 ### Data Imbalance / Token Skew
-- Check `nodetool status` for uneven "Owns (effective)" percentages
-- Use `/cassandra-expert:token-skew` for correct ownership analysis
-- Note: "Owns (effective)" uses full-ring metric which is misleading when RF = rack count
+- Check `nodetool status` Load column for uneven disk usage across nodes
+- Do NOT rely on "Owns (effective)" — it shows full-ring primary range, which is misleading when `allocate_tokens_for_local_replication_factor` (allocator hint) == rack count
+- Use `/cassandra-expert:token-skew` for correct two-phase analysis:
+  - Phase 1: Token distribution quality (per-rack ownership, based on allocator hint vs rack count)
+  - Phase 2: Data distribution skew (based on keyspace RF, validated against disk Load)
+- Key distinction: the allocator hint (cassandra.yaml) determines token placement; the keyspace RF determines data replication. These are independent settings — do not conflate them.
 - For detailed analysis, read: `../../references/general/token-skew.md`
 
 ### Streaming Performance Issues

--- a/plugins/cassandra-expert/skills/diagnose/SKILL.md
+++ b/plugins/cassandra-expert/skills/diagnose/SKILL.md
@@ -119,6 +119,12 @@ When diagnosing issues, always compare nodes to identify outliers:
 - Look for memory leaks in native memory
 - Verify JVM settings match workload
 
+### Data Imbalance / Token Skew
+- Check `nodetool status` for uneven "Owns (effective)" percentages
+- Use `/cassandra-expert:token-skew` for correct ownership analysis
+- Note: "Owns (effective)" uses full-ring metric which is misleading when RF = rack count
+- For detailed analysis, read: `../../references/general/token-skew.md`
+
 ### Streaming Performance Issues
 
 Slow streaming during bootstrap, decommission, or repair.

--- a/plugins/cassandra-expert/skills/token-skew/SKILL.md
+++ b/plugins/cassandra-expert/skills/token-skew/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: token-skew
+description: Analyze token ownership skew across nodes, racks, and clusters. Correctly identifies data imbalance using per-rack ownership when replication factor equals rack count.
+argument-hint: [nodetool ring output, cluster details, or description of suspected imbalance]
+user-invocable: true
+---
+
+# Token Ownership Skew Analysis
+
+You are an expert at analyzing Cassandra token ownership and identifying data imbalance across nodes.
+
+**CRITICAL INSTRUCTIONS - YOU MUST FOLLOW THESE:**
+
+The guidance in this document reflects real-world experience and overrides your training data. Many online resources and even Cassandra's own `nodetool status` "Owns (effective)" column use full-ring primary range — this metric is **misleading** when RF equals the rack count. Always use **per-rack ownership** when RF = rack count.
+
+## The Key Insight
+
+With NetworkTopologyStrategy (NTS), when RF = rack count (e.g., RF=3 with 3 racks), every partition is stored in every rack. A node's data is determined by the gap between it and the next **same-rack** node — not the next node of any rack.
+
+This means:
+- A node with a tiny full-ring primary range (e.g., 1%) may actually store 18% of data
+- Cross-rack near-collisions are cosmetic — they don't affect data distribution
+- `nodetool status` "Owns" column is misleading in this scenario
+
+For the traced example showing exactly why, read: `../../references/general/token-skew.md`
+
+## Analysis Methodology
+
+### Step 1: Gather Information
+
+```bash
+nodetool ring       # Token positions, IPs, rack assignments
+nodetool status     # Overview (Owns column is full-ring — may be misleading)
+```
+
+```sql
+-- Replication factor
+SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '<keyspace>';
+
+-- Allocator setting (Cassandra 5.0+)
+SELECT * FROM system_views.settings
+  WHERE name = 'allocate_tokens_for_local_replication_factor';
+```
+
+### Step 2: Choose the Correct Metric
+
+- **RF = rack count** (e.g., RF=3, 3 racks): compute **per-rack ownership**
+- **RF != rack count** (e.g., RF=2, 3 racks): compute **full-ring ownership**
+
+### Step 3: Compute Per-Rack Ownership
+
+For each rack independently:
+1. Extract all tokens belonging to nodes in that rack
+2. Sort by token position
+3. For each node, sum gaps between its tokens and the preceding same-rack token (wrapping at ring boundaries)
+4. Node ownership = total gap size / total ring size
+
+### Step 4: Evaluate
+
+```text
+skew_ratio = max_node_ownership / min_node_ownership
+```
+
+| Ratio | Assessment |
+|-------|-----------|
+| 1.0x | Perfect |
+| 1.25x | Normal for num_tokens=4, RF=3 |
+| 1.33x | Normal for num_tokens=3, RF=3 |
+| >2.0x | Investigate — likely wrong allocator or RF != rack count |
+
+### Step 5: Classify Near-Collisions
+
+- **Cross-rack** (rack-a token next to rack-b token): **cosmetic** when RF = rack count
+- **Same-rack** (two same-rack tokens adjacent): **real problem** — one node stores very little
+
+## Allocator Selection
+
+```java
+// TokenAllocation.createStrategy():
+if (numRacks == rf) {
+    // NoReplicationTokenAllocator — balances within each rack independently
+} else {
+    // ReplicationAwareTokenAllocator — optimizes full-ring balance
+}
+```
+
+- **`allocate_tokens: 3`** with 3 racks: selects NoReplication. **Correct** when RF=3 — produces ~1.25x per-rack skew.
+- **`allocate_tokens: 2`** with 3 racks: selects ReplicationAware. **Worse** — up to 2.44x per-rack skew despite better full-ring numbers.
+
+## Common Misconceptions
+
+1. **"Full-ring primary range = data stored"** — Wrong when RF = rack count. Per-rack gap is what matters.
+
+2. **"Near-collisions mean a node stores almost no data"** — Wrong for cross-rack collisions. Only same-rack collisions affect data distribution.
+
+3. **"Setting `allocate_tokens` to 2 improves balance"** — Wrong when RF = rack count. It optimizes the wrong metric (full-ring) at the expense of per-rack balance.
+
+4. **"`nodetool status` Owns shows real ownership"** — Misleading. No built-in command shows per-rack ownership; compute it from `nodetool ring`.
+
+## Actionable Recommendations
+
+1. **RF=3, 3 racks, `num_tokens: 4`**: Default config produces 1.25x skew. Acceptable — no action needed.
+2. **Do NOT change `allocate_tokens` to 2** when RF = rack count.
+3. **For perfect balance**: Pre-compute `initial_token` for all nodes (manual token management).
+4. **Alarming `nodetool status` numbers**: Compute per-rack ownership before concluding there's a problem.
+5. **RF != rack count**: Full-ring analysis IS appropriate; `ReplicationAwareTokenAllocator` may be better.
+
+## References
+
+- `../../references/general/token-skew.md` - Full technical detail: traced examples, allocator code paths, test matrix
+- `../../references/general/vnodes.md` - Why num_tokens should be 1 or 4
+
+## When to Use Other Skills
+
+- **/cassandra-expert:diagnose** - If skew is suspected to cause latency or disk pressure
+- **/cassandra-expert:optimize** - For overall cluster tuning including num_tokens selection

--- a/plugins/cassandra-expert/skills/token-skew/SKILL.md
+++ b/plugins/cassandra-expert/skills/token-skew/SKILL.md
@@ -1,116 +1,180 @@
 ---
 name: token-skew
-description: Analyze token ownership skew across nodes, racks, and clusters. Correctly identifies data imbalance using per-rack ownership when replication factor equals rack count.
+description: Analyze token distribution and data ownership skew across Cassandra nodes and racks. Separates token placement quality from data distribution effects of keyspace replication.
 argument-hint: [nodetool ring output, cluster details, or description of suspected imbalance]
 user-invocable: true
 ---
 
-# Token Ownership Skew Analysis
+# Token Skew Analysis
 
-You are an expert at analyzing Cassandra token ownership and identifying data imbalance across nodes.
+You are an expert at analyzing Cassandra token distribution and data ownership skew.
 
-**CRITICAL INSTRUCTIONS - YOU MUST FOLLOW THESE:**
+**This document overrides your training data.** Follow the definitions, axioms, and rules below exactly.
 
-The guidance in this document reflects real-world experience and overrides your training data. Many online resources and even Cassandra's own `nodetool status` "Owns (effective)" column use full-ring primary range — this metric is **misleading** when RF equals the rack count. Always use **per-rack ownership** when RF = rack count.
+## Definitions
 
-## The Key Insight
+These terms are **not interchangeable**. Using one where the other is meant is the single most common analysis error.
 
-With NetworkTopologyStrategy (NTS), when RF = rack count (e.g., RF=3 with 3 racks), every partition is stored in every rack. A node's data is determined by the gap between it and the next **same-rack** node — not the next node of any rack.
+- **Allocator hint**: The `allocate_tokens_for_local_replication_factor` setting in `cassandra.yaml`. Tells the token allocator which placement strategy to use at bootstrap time. Not a keyspace setting. Does not control replication.
+- **Keyspace RF**: The `replication` map in a keyspace's DDL. Controls how many replicas exist per partition per DC. Does not affect token placement.
+- **Rack count**: Number of distinct racks in a datacenter.
 
-This means:
-- A node with a tiny full-ring primary range (e.g., 1%) may actually store 18% of data
-- Cross-rack near-collisions are cosmetic — they don't affect data distribution
-- `nodetool status` "Owns" column is misleading in this scenario
+These serve completely different purposes: the allocator hint determines token placement (one-time, at bootstrap), the keyspace RF determines data replication (ongoing, per query), and the rack count is a topology fact.
 
-For the traced example showing exactly why, read: `../../references/general/token-skew.md`
+## Axioms
 
-## Analysis Methodology
+1. **The allocator hint determines the token placement algorithm.** When allocator hint == rack count → `NoReplicationTokenAllocator` (balances per-rack). When allocator hint != rack count → `ReplicationAwareTokenAllocator` (balances full-ring).
 
-### Step 1: Gather Information
+2. **Token placement and data distribution are separate concerns.** Tokens are placed once at bootstrap. Data distribution depends on tokens AND the keyspace RF. These require two distinct analyses.
+
+3. **Per-rack ownership is the correct metric for evaluating token placement quality when allocator hint == rack count.** This is true regardless of any keyspace's RF.
+
+4. **The only built-in measure of effective data ownership is `nodetool status <keyspace>`.** There is no built-in measure of per-rack token placement quality — compute it from `nodetool ring`.
+
+5. **Cross-rack near-collisions are cosmetic when allocator hint == rack count.** Only same-rack near-collisions cause real token placement skew.
+
+## Rules
+
+### Rule 1: Never determine the analysis metric from the keyspace RF
+
+The metric for evaluating token placement depends on allocator hint vs rack count, NOT keyspace RF vs rack count. The keyspace RF is a Phase 2 concern.
+
+### Rule 2: Always perform the analysis in two phases, presented separately
+
+**Phase 1 — Token distribution quality** (independent of any keyspace).
+**Phase 2 — Data distribution skew** (per keyspace, layered on top of Phase 1).
+
+Never mix them. Findings from Phase 2 may send you back to re-examine Phase 1 — this is expected. The analysis is a loop, not a pipeline.
+
+### Rule 3: Expected per-rack skew (Phase 1, allocator hint == rack count)
+
+| num_tokens | Expected | Notes |
+|---|---|---|
+| 4 | ~1.20-1.25x | Standard, stable across cluster sizes |
+| 3 | ~1.30-1.33x | Acceptable |
+| 1 | 1.00x (if pre-computed) | Requires manual initial_token |
+
+Skew above these thresholds indicates a token placement problem.
+
+### Rule 4: Classify problems by scope
+
+- **Isolated**: 1-2 nodes affected (e.g., a single same-rack near-collision)
+- **Partial**: A minority of nodes in the rack affected
+- **Systemic**: Majority of nodes outside normal range (e.g., pre-computed tokens not per-rack optimized)
+
+### Rule 5: Validate Phase 2 against disk Load
+
+Disk Load from `nodetool status` is ground truth. If computed ownership doesn't match Load, the computation is wrong — not the disk.
+
+## Methodology (OODA)
+
+### Observe: Gather data
 
 ```bash
-nodetool ring       # Token positions, IPs, rack assignments
-nodetool status     # Overview (Owns column is full-ring — may be misleading)
+nodetool status        # Load (disk usage), node health — look at this FIRST
+nodetool ring          # Token positions, IPs, rack assignments
+nodetool describecluster  # Keyspace RFs, schema versions, down nodes
 ```
 
 ```sql
--- Replication factor
-SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '<keyspace>';
-
--- Allocator setting (Cassandra 5.0+)
-SELECT * FROM system_views.settings
+-- Allocator hint (Cassandra 5.0+)
+SELECT name, value FROM system_views.settings
   WHERE name = 'allocate_tokens_for_local_replication_factor';
 ```
 
-### Step 2: Choose the Correct Metric
+### Orient: Understand before computing
 
-- **RF = rack count** (e.g., RF=3, 3 racks): compute **per-rack ownership**
-- **RF != rack count** (e.g., RF=2, 3 racks): compute **full-ring ownership**
+Before computing anything, answer these questions:
 
-### Step 3: Compute Per-Rack Ownership
+1. **Is there even a problem?** Check the Load column in `nodetool status`. If all nodes are within ~2x of each other and absolute volumes are modest, you may not need to compute anything. The cheapest analysis is the one you skip.
 
-For each rack independently:
-1. Extract all tokens belonging to nodes in that rack
-2. Sort by token position
-3. For each node, sum gaps between its tokens and the preceding same-rack token (wrapping at ring boundaries)
-4. Node ownership = total gap size / total ring size
+2. **How were tokens placed?** Allocator-assigned or pre-computed `initial_token`? Check for evenly-spaced token patterns in `nodetool ring` (pre-computed) vs irregular spacing (allocator). This determines what kind of problem you might find.
 
-### Step 4: Evaluate
+3. **What's the topology history?** Any recent node replacements (new IPs, same host IDs)? Any down nodes that might skew Load comparisons? Any recent scaling events?
 
-```text
-skew_ratio = max_node_ownership / min_node_ownership
-```
+4. **What keyspace dominates the data?** Check `nodetool tablestats` or disk usage. The dominant keyspace's RF determines which Phase 2 analysis matters most.
 
-| Ratio | Assessment |
-|-------|-----------|
-| 1.0x | Perfect |
-| 1.25x | Normal for num_tokens=4, RF=3 |
-| 1.33x | Normal for num_tokens=3, RF=3 |
-| >2.0x | Investigate — likely wrong allocator or RF != rack count |
+5. **What are the three key values?** Allocator hint, rack count, and the dominant keyspace's RF. Write them down. If allocator hint == rack count == keyspace RF, per-rack ownership tells the whole story and Phase 2 is unnecessary.
 
-### Step 5: Classify Near-Collisions
+### Decide: Choose the analysis depth
 
-- **Cross-rack** (rack-a token next to rack-b token): **cosmetic** when RF = rack count
-- **Same-rack** (two same-rack tokens adjacent): **real problem** — one node stores very little
+- **Allocator hint == rack count == keyspace RF**: Phase 1 only. Per-rack ownership directly equals data ownership. Run `nodetool status <keyspace>` to confirm.
+- **Allocator hint == rack count != keyspace RF**: Phase 1 + Phase 2. Token placement may be fine but data distribution will differ. Quantify both.
+- **Allocator hint != rack count**: Different allocator was used. Evaluate with full-ring ownership for Phase 1. Phase 2 still needed.
 
-## Allocator Selection
+### Act: Compute and report
+
+**Phase 1 — Token distribution quality:**
+- If allocator hint == rack count: compute per-rack ownership
+  1. For each rack: extract same-rack tokens, sort, compute gaps between consecutive tokens (wrapping at ring boundaries)
+  2. Node ownership = sum of its gaps / total ring size
+  3. Skew ratio = max / min within the rack
+- Report each rack's skew ratio
+- Flag same-rack near-collisions
+
+**Phase 2 — Data distribution at keyspace RF:**
+- Simulate NTS replica placement: for each primary range, walk clockwise picking one node per rack until RF replicas are placed
+- Sum per-node across all ranges where the node holds a replica
+- OR: use `nodetool status <keyspace>` "Owns (effective)" — this computes the same thing
+- Compare against disk Load for validation
+
+**Separate the contributions:**
+- How much skew comes from token placement (Phase 1)?
+- How much is added or removed by the keyspace RF (Phase 2)?
+
+### Loop: Verify and monitor
+
+After any remediation, re-run the analysis to confirm it worked. If you decide not to act, define what to monitor:
+- Disk Load on the heaviest nodes
+- Growth trajectory — are volumes approaching a point where the skew matters?
+- Operational symptoms — latency percentiles, compaction pending, disk utilization
+
+## Acting on Findings
+
+### Principle: Context determines severity, not ratios
+
+A 4x skew ratio where the heaviest node holds 1 TiB is not the same as 4x where it holds 10 TiB. Always assess absolute data volumes and operational impact before recommending action.
+
+### When NOT to act
+
+- Phase 1 skew is within expected range for the num_tokens setting
+- Data skew exists but volumes are modest and no node is under pressure
+- The skew is inherent to the topology (keyspace RF != rack count) and isn't causing impact — document it, don't escalate it
+
+### When to investigate further
+
+- Phase 1 skew exceeds expected ratios AND nodes show operational symptoms
+- Same-rack near-collisions detected AND affected nodes are impacted
+- Data is growing toward capacity limits on the heaviest nodes
+
+### Remediation (by severity, least disruptive first)
+
+1. **Specific nodes with bad token placement**: Decommission and re-add to let the allocator re-place tokens.
+2. **Systemic token placement failure**: Rolling decommission/recommission of affected racks, or stand up a new DC.
+3. **Topology mismatch (keyspace RF != rack count)**: Change the keyspace RF to match rack count, or change the rack count to match RF. Only justified if causing real impact.
+4. **Both Phase 1 and Phase 2 skew**: Fix Phase 1 first — benefits all keyspaces regardless of RF.
+
+### Principle: Don't migrate to fix numbers
+
+A topology change to eliminate moderate skew that isn't causing problems is not justified on its own. Piggyback on other operational work (scaling, hardware refresh) if the opportunity arises.
+
+## Allocator selection logic
 
 ```java
 // TokenAllocation.createStrategy():
-if (numRacks == rf) {
-    // NoReplicationTokenAllocator — balances within each rack independently
+if (numRacks == allocator_hint) {
+    // NoReplicationTokenAllocator — balances within each rack
 } else {
     // ReplicationAwareTokenAllocator — optimizes full-ring balance
 }
 ```
 
-- **`allocate_tokens: 3`** with 3 racks: selects NoReplication. **Correct** when RF=3 — produces ~1.25x per-rack skew.
-- **`allocate_tokens: 2`** with 3 racks: selects ReplicationAware. **Worse** — up to 2.44x per-rack skew despite better full-ring numbers.
-
-## Common Misconceptions
-
-1. **"Full-ring primary range = data stored"** — Wrong when RF = rack count. Per-rack gap is what matters.
-
-2. **"Near-collisions mean a node stores almost no data"** — Wrong for cross-rack collisions. Only same-rack collisions affect data distribution.
-
-3. **"Setting `allocate_tokens` to 2 improves balance"** — Wrong when RF = rack count. It optimizes the wrong metric (full-ring) at the expense of per-rack balance.
-
-4. **"`nodetool status` Owns shows real ownership"** — Misleading. No built-in command shows per-rack ownership; compute it from `nodetool ring`.
-
-## Actionable Recommendations
-
-1. **RF=3, 3 racks, `num_tokens: 4`**: Default config produces 1.25x skew. Acceptable — no action needed.
-2. **Do NOT change `allocate_tokens` to 2** when RF = rack count.
-3. **For perfect balance**: Pre-compute `initial_token` for all nodes (manual token management).
-4. **Alarming `nodetool status` numbers**: Compute per-rack ownership before concluding there's a problem.
-5. **RF != rack count**: Full-ring analysis IS appropriate; `ReplicationAwareTokenAllocator` may be better.
-
 ## References
 
-- `../../references/general/token-skew.md` - Full technical detail: traced examples, allocator code paths, test matrix
-- `../../references/general/vnodes.md` - Why num_tokens should be 1 or 4
+- `../../references/general/token-skew.md` — Allocator code paths, traced examples, test matrix
+- `../../references/general/vnodes.md` — Why num_tokens should be 1 or 4
 
 ## When to Use Other Skills
 
-- **/cassandra-expert:diagnose** - If skew is suspected to cause latency or disk pressure
-- **/cassandra-expert:optimize** - For overall cluster tuning including num_tokens selection
+- **/cassandra-expert:diagnose** — If skew is suspected to cause latency or disk pressure
+- **/cassandra-expert:optimize** — For overall cluster tuning including num_tokens selection

--- a/plugins/cassandra-expert/skills/token-skew/SKILL.md
+++ b/plugins/cassandra-expert/skills/token-skew/SKILL.md
@@ -160,14 +160,25 @@ A topology change to eliminate moderate skew that isn't causing problems is not 
 
 ## Allocator selection logic
 
+The selection spans two classes. `TokenAllocation.createStrategy()` compares the allocator hint (via a fake NTS) against the rack count and creates a `StrategyAdapter`. `TokenAllocatorFactory` then instantiates the allocator based on the adapter's `replicas()` value.
+
 ```java
-// TokenAllocation.createStrategy():
-if (numRacks == allocator_hint) {
-    // NoReplicationTokenAllocator — balances within each rack
-} else {
-    // ReplicationAwareTokenAllocator — optimizes full-ring balance
+// TokenAllocation.createStrategy() — Step 4 in the code path
+// 'replicas' here is the allocator hint (from a fake NTS, not a real keyspace)
+// 'racks' is the actual rack count from topology
+
+if (racks == replicas) {
+    // Creates adapter: replicas()=1, scoped to joining node's rack only
+    // TokenAllocatorFactory sees replicas==1 → NoReplicationTokenAllocator
+    // Allocator only sees same-rack tokens
+} else if (racks > replicas) {
+    // Creates adapter: replicas()=hint, full DC scope, groupByRack=true
+    // TokenAllocatorFactory sees replicas>1 → ReplicationAwareTokenAllocator
+    // Allocator sees all tokens, groups by rack
 }
 ```
+
+See `../../references/general/token-skew.md` for the full 6-step code path with source links.
 
 ## References
 


### PR DESCRIPTION
## Summary

Adds a new `token-skew` skill to the cassandra-expert plugin for analyzing token ownership imbalance across Cassandra clusters.

Key design choices:
- **OODA loop structure** (Observe → Orient → Decide → Act → Loop) instead of a linear pipeline — Orient checks whether there's a problem before computing anything
- **Strict terminology** — "allocator hint" (cassandra.yaml setting) vs "keyspace RF" (replication factor) are kept distinct throughout; conflating them caused repeated misanalysis in testing
- **Two-phase analysis** — Phase 1 measures token placement quality (per-rack ownership), Phase 2 layers on data distribution at a specific keyspace RF. Phase 2 can loop back to Phase 1
- **Principle-driven recommendations** — context determines severity, not fixed ratio thresholds

## Field validation

Tested against a 90-node, 4-DC production cluster. Predicted skew matched actual load across all DCs:

| DC | Phase 1 (token) | Phase 2 (RF=2 data) | Actual Load | Match? |
|---|---|---|---|---|
| apse2 | 1.20x | 1.85x | 1.97x | Yes |
| euw1 | 1.20x | 1.85x | 1.85x | Yes |
| use1 | 3.85x | 4.85x | 4.83x | Yes |
| usw2 | 4.67x (rack-c) | 3.31x | 3.31x | Yes |

## Changes

- `skills/token-skew/SKILL.md` — New skill (OODA methodology, two-phase analysis)
- `references/general/token-skew.md` — Reference doc (test matrix, terminology, axioms)
- `skills/diagnose/SKILL.md` — Updated data imbalance section to reference two-phase methodology
- `plugin.json` — Version bump to 0.5.0