### PR TITLE
Add Codex plugin support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "rustyrazorblade-plugins",
+  "interface": {
+    "displayName": "Rustyrazorblade Skills"
+  },
+  "plugins": [
+    {
+      "name": "cassandra-expert",
+      "source": {
+        "source": "local",
+        "path": "./plugins/cassandra-expert"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # Rustyrazorblade Skills
 
-A Claude Code plugin marketplace by Jon Haddad.
+A plugin marketplace by Jon Haddad.
 
 ## Installation
 
+### Claude Code
 ```
 /plugin marketplace add rustyrazorblade/skills
 ```
+
+### Codex
+```
+codex plugin marketplace add rustyrazorblade/skills
+```
+
+Codex exposes skills through `$` mentions instead of slash commands.
 
 ## Available Plugins
 
@@ -14,8 +22,18 @@ A Claude Code plugin marketplace by Jon Haddad.
 
 Expert guidance for Apache Cassandra development and operations.
 
+Claude Code:
+
 ```
 /plugin install cassandra-expert@rustyrazorblade-plugins
+```
+
+Codex CLI:
+
+Install `cassandra-expert` from the plugins section:
+
+```
+/plugins
 ```
 
 #### Skills

--- a/plugins/cassandra-expert/.codex-plugin/plugin.json
+++ b/plugins/cassandra-expert/.codex-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "cassandra-expert",
+  "version": "0.5.0",
+  "description": "Expert guidance for Apache Cassandra development, including schema design, query optimization, performance tuning, and operational best practices.",
+  "author": {
+    "name": "Jon Haddad"
+  },
+  "repository": "https://github.com/rustyrazorblade/skills",
+  "license": "Apache-2.0",
+  "keywords": ["cassandra", "database", "nosql", "cql", "schema", "performance", "token-skew"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Cassandra Expert",
+    "shortDescription": "Expert guidance for Apache Cassandra development and operations.",
+    "developerName": "Jon Haddad",
+    "category": "Productivity",
+    "capabilities": [
+      "Read"
+    ]
+  }
+}


### PR DESCRIPTION
Adds minimal Codex plugin support for the existing cassandra-expert plugin.

Changes:
- Adds a Codex repo marketplace at `.agents/plugins/marketplace.json`
- Adds a Codex plugin manifest at `plugins/cassandra-expert/.codex-plugin/plugin.json`
- Adds a short README note for local Codex installation and `$` skill mentions

No existing skill content or Claude plugin metadata is changed.