### PR TITLE
Add easy-db-lab plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,10 @@
 {
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true
+  },
+  "permissions": {
+    "allow": [
+      "Bash(easy-db-lab *)"
+    ]
   }
 }

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export CLAUDE=$(which claude)
+PATH_add bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .worktrees/
 cassandra-upstream/
+/tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,22 @@ bin/claude
 
 This is required because there is no declarative way to register a local plugin directory in `.claude/settings.json`. The `--plugin-dir` flag is the only mechanism for local plugin testing.
 
+## Version Bumping
+
+When working on a branch or PR, ask if the user wants to bump the plugin version. Show the current version and ask for the new one before making any changes.
+
+Version is declared in two files per plugin — both must be updated together:
+- `plugins/<plugin>/.claude-plugin/plugin.json` — `version` field
+- `plugins/<plugin>/.codex-plugin/plugin.json` — `version` field
+
+Example:
+```
+Current version: 0.1.0
+What should the new version be?
+```
+
+Once confirmed, update both files. Do not bump the version without asking first.
+
 ## cassandra-expert Plugin
 
 ### Training Skill Architecture

--- a/README.md
+++ b/README.md
@@ -117,6 +117,53 @@ Opinionated guidance based on real-world experience:
 - **Partitions**: Keep under 10MB. No downside to smaller partitions.
 - **Row cache**: Keep disabled. Rarely beneficial.
 
+### easy-db-lab
+
+Provision and operate AWS lab environments with Cassandra, ClickHouse, Spark, OpenSearch, and installable kits.
+
+Claude Code:
+
+```
+/plugin install easy-db-lab@rustyrazorblade-plugins
+```
+
+Codex CLI:
+
+Install `easy-db-lab` from the plugins section:
+
+```
+/plugins
+```
+
+#### Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `/easy-db-lab:explore` | **Start here** — interactive guided session that provisions an environment if needed, then helps you run tests and explore the cluster |
+| `/easy-db-lab:provision` | Provision single or multi-DC environments including VPC peering, security groups, and Cassandra seed coordination |
+| `/easy-db-lab:plan` | Interactively design a lab workflow and write it to `plan.md` |
+| `/easy-db-lab:install` | Install and operate kits (databases, analytics engines, query engines, apps) |
+| `/easy-db-lab:run` | Execute a `plan.md` step by step, confirming each step with the user and recording progress in `history.md` |
+
+#### Usage Examples
+
+```
+/easy-db-lab:explore
+/easy-db-lab:explore cassandra 5.0
+/easy-db-lab:explore clickhouse analytics
+/easy-db-lab:provision 3 node Cassandra cluster on m5.2xlarge
+/easy-db-lab:provision 2 DCs, 3 nodes each, multi-DC setup
+/easy-db-lab:plan benchmark Cassandra 5.0 vs 4.1
+/easy-db-lab:install list available kits
+```
+
+#### Notes
+
+- Skills must be run from a lab workspace directory (created by `easy-db-lab init`)
+- Each DC in a multi-DC setup has its own subdirectory with independent state
+- Session activity is tracked in `history.md` in the workspace directory
+- Plans are written to `plan.md`
+
 ## License
 
 Apache 2.0

--- a/bin/claude
+++ b/bin/claude
@@ -1,5 +1,10 @@
 #!/bin/bash
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLUGIN_DIR="$SCRIPT_DIR/../plugins/cassandra-expert"
+PLUGINS_DIR="$SCRIPT_DIR/../plugins"
 
-exec claude --plugin-dir "$PLUGIN_DIR" "$@"
+PLUGIN_ARGS=()
+for dir in "$PLUGINS_DIR"/*/; do
+  PLUGIN_ARGS+=(--plugin-dir "$dir")
+done
+
+exec "${CLAUDE:-claude}" "${PLUGIN_ARGS[@]}" "$@"

--- a/plugins/cassandra-expert/.codex-plugin/plugin.json
+++ b/plugins/cassandra-expert/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-expert",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Expert guidance for Apache Cassandra development, including schema design, query optimization, performance tuning, and operational best practices.",
   "author": {
     "name": "Jon Haddad"

--- a/plugins/easy-db-lab/.claude-plugin/plugin.json
+++ b/plugins/easy-db-lab/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "easy-db-lab",
+  "description": "Guided workflow assistant for easy-db-lab — provision AWS lab environments, manage Cassandra and ClickHouse clusters, run stress tests, and operate observability tooling.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jon Haddad"
+  },
+  "repository": "https://github.com/rustyrazorblade/skills",
+  "license": "Apache-2.0",
+  "keywords": ["easy-db-lab", "cassandra", "aws", "lab", "stress-testing", "clickhouse"]
+}

--- a/plugins/easy-db-lab/.codex-plugin/plugin.json
+++ b/plugins/easy-db-lab/.codex-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "easy-db-lab",
+  "version": "0.1.0",
+  "description": "Guided workflow assistant for easy-db-lab — provision AWS lab environments, manage Cassandra and ClickHouse clusters, run stress tests, and operate observability tooling.",
+  "author": {
+    "name": "Jon Haddad"
+  },
+  "repository": "https://github.com/rustyrazorblade/skills",
+  "license": "Apache-2.0",
+  "keywords": ["easy-db-lab", "cassandra", "aws", "lab", "stress-testing", "clickhouse"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Easy DB Lab",
+    "shortDescription": "Provision and operate AWS lab environments with Cassandra, ClickHouse, and stress testing.",
+    "developerName": "Jon Haddad",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Bash"
+    ]
+  }
+}

--- a/plugins/easy-db-lab/references/cassandra.md
+++ b/plugins/easy-db-lab/references/cassandra.md
@@ -1,0 +1,260 @@
+# Cassandra Workflow
+
+Cassandra runs directly on the EC2 instances — not in Kubernetes. Do not use `kubectl` for any Cassandra operations. The Cassandra sidecar runs in k8s on port 9043.
+
+## Select Version
+
+```bash
+# Available: 3.0, 3.11, 4.0, 4.1 (check `easy-db-lab cassandra list` for current list)
+easy-db-lab cassandra use 5.0
+
+# Override Java version (8, 11, or 17)
+easy-db-lab cassandra use 5.0 --java 17
+
+# Target specific nodes
+easy-db-lab cassandra use 5.0 --hosts db0,db1
+
+# List available versions
+easy-db-lab cassandra list
+```
+
+## Configuration
+
+**Never change the snitch.** easy-db-lab configures `Ec2Snitch` automatically. Do not set `endpoint_snitch` in `cassandra.patch.yaml` or override it in any config command.
+
+**Never overwrite an existing `cassandra.patch.yaml`.** `easy-db-lab cassandra use <version>` generates this file with correct settings (snitch, data directory paths, etc.). Always read the existing file and merge new keys into it. Replacing it with a minimal stub destroys those settings and will break the cluster.
+
+```bash
+# Download current JVM and YAML config files locally
+easy-db-lab cassandra download-config
+easy-db-lab cassandra download-config --hosts db0
+
+# Write a new cassandra.yaml patch file
+easy-db-lab cassandra write-config my-patch.yaml
+easy-db-lab cassandra write-config my-patch.yaml --tokens 4
+
+# Push patch to all nodes
+easy-db-lab cassandra update-config my-patch.yaml
+
+# Push and restart in one step
+easy-db-lab cassandra update-config my-patch.yaml --restart
+
+# Target specific nodes
+easy-db-lab cassandra update-config my-patch.yaml --hosts db0,db1
+```
+
+Config workflow: `download-config` → edit the YAML fragment → `update-config <file> [--restart]`
+
+## Multi-DC Setup
+
+This is the only correct procedure for multi-DC Cassandra. Follow it exactly — do not deviate.
+
+### Prerequisites
+
+VPC peering and security groups between DCs must already be in place (handled by `/easy-db-lab:provision`). Each DC lives in its own workspace directory (e.g. `dc1/`, `dc2/`). All `easy-db-lab` commands for a DC must be run from its directory.
+
+### Step 1 — Select a Cassandra version in each DC
+
+```bash
+cd dc1 && easy-db-lab cassandra use 5.0 && cd ..
+cd dc2 && easy-db-lab cassandra use 5.0 && cd ..
+```
+
+### Step 2 — Set dc_suffix on each DC
+
+easy-db-lab uses `Ec2Snitch`, which sets the DC name to the AWS region (e.g. `us-east-1`). The `dc_suffix` is appended to the region to produce the final DC name — so `dc_suffix=_dc1` in `us-east-1` gives `us-east-1_dc1`.
+
+Write a `cassandra-rackdc.properties` file in the version directory for each DC:
+
+```bash
+# In dc1/
+echo "dc_suffix=_dc1" > 5.0/cassandra-rackdc.properties
+
+# In dc2/
+echo "dc_suffix=_dc2" > 5.0/cassandra-rackdc.properties
+```
+
+**Never set `endpoint_snitch` or `dc` directly.** Ec2Snitch is already configured — changing it will break the cluster.
+
+### Step 3 — Configure cluster name and cross-DC seeds
+
+All DCs must share the same `cluster_name`. Seeds must include at least one node from each DC. The node IPs are available from `easy-db-lab status` output.
+
+**Read the existing `cassandra.patch.yaml` before editing it.** `easy-db-lab cassandra use <version>` generates this file with correct snitch and data directory settings. Merge new keys in — never replace the file.
+
+Merge the following into each DC's `cassandra.patch.yaml`:
+
+```yaml
+cluster_name: "<cluster-name>"
+seed_provider:
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      - seeds: "<dc1-db0-ip>,<dc2-db0-ip>"
+```
+
+**If this cluster will use bulk SSTable import (e.g. IAM Bulk Writer, Spark), also add:**
+
+```yaml
+storage_compatibility_mode: NONE
+```
+
+Without this setting the sidecar will create restore jobs and immediately mark them removed without importing any data. The symptom is `inflightJobsCount=0` and `SELECT COUNT(*)` returning 0 after a successful Spark job.
+
+Push to each DC:
+
+```bash
+cd dc1 && easy-db-lab cassandra update-config cassandra.patch.yaml && cd ..
+cd dc2 && easy-db-lab cassandra update-config cassandra.patch.yaml && cd ..
+```
+
+### Step 4 — Start and verify
+
+Start Cassandra in each DC (can be done in parallel):
+
+```bash
+(cd dc1 && easy-db-lab cassandra start) &
+(cd dc2 && easy-db-lab cassandra start) &
+wait
+```
+
+Verify all nodes from any DC:
+
+```bash
+cd dc1 && easy-db-lab cassandra nt status
+```
+
+All nodes from both DCs should appear. Each node's DC column should show `us-east-1_dc1` or `us-east-1_dc2`.
+
+### Step 5 — Configure S3 bucket replication (for bulk import workflows)
+
+If the workload writes SSTables to S3 (e.g. IAM Bulk Writer), replicate the source DC's bucket to the target DC's bucket.
+
+**Find the replication IAM role** (one pre-created role exists per environment — search by name):
+
+```bash
+aws iam list-roles --query "Roles[?contains(RoleName, 'replication')].{Name:RoleName,Arn:Arn}" --output table
+```
+
+**Enable versioning** on both buckets (required for S3 replication):
+
+```bash
+DC1_BUCKET=$(cd dc1 && easy-db-lab aws s3-bucket)
+DC2_BUCKET=$(cd dc2 && easy-db-lab aws s3-bucket)
+
+aws s3api put-bucket-versioning --bucket $DC1_BUCKET --versioning-configuration Status=Enabled
+aws s3api put-bucket-versioning --bucket $DC2_BUCKET --versioning-configuration Status=Enabled
+```
+
+**Apply the replication configuration** to the source bucket:
+
+```bash
+REPLICATION_ROLE_ARN=$(aws iam list-roles --query "Roles[?contains(RoleName, 'replication')].Arn" --output text)
+
+aws s3api put-bucket-replication \
+  --bucket $DC1_BUCKET \
+  --replication-configuration "{
+    \"Role\": \"$REPLICATION_ROLE_ARN\",
+    \"Rules\": [{
+      \"Status\": \"Enabled\",
+      \"Filter\": {\"Prefix\": \"\"},
+      \"Destination\": {\"Bucket\": \"arn:aws:s3:::$DC2_BUCKET\"}
+    }]
+  }"
+```
+
+Replication is asynchronous. Objects written to `$DC1_BUCKET` will appear in `$DC2_BUCKET` within seconds to minutes depending on object size.
+
+## Start / Stop / Restart
+
+```bash
+# Start Cassandra on all nodes (staggered by default)
+easy-db-lab cassandra start
+
+# Control sleep time between node starts (seconds)
+easy-db-lab cassandra start --sleep 30
+
+# Use a custom sidecar image (e.g. a custom ECR build for bulk import)
+easy-db-lab cassandra start --sidecar-image <image-uri>
+
+# Stop all nodes
+easy-db-lab cassandra stop
+
+# Restart all nodes
+easy-db-lab cassandra restart
+
+# Target specific nodes with --hosts on any command
+easy-db-lab cassandra start --hosts db0
+easy-db-lab cassandra stop --hosts db1,db2
+```
+
+**Changing the sidecar image on a running cluster:** The sidecar runs as a DaemonSet in k3s. Passing `--sidecar-image` only takes effect on a fresh start. If the cluster is already running with a different image, delete the existing DaemonSet first:
+
+```bash
+kubectl delete daemonset -n cassandra-sidecar --all
+easy-db-lab cassandra start --sidecar-image <image-uri>
+```
+
+## Verify the Cluster
+
+```bash
+# Nodetool commands (args passed directly to nodetool)
+easy-db-lab cassandra nt status
+easy-db-lab cassandra nt ring
+easy-db-lab cassandra nt compactionstats
+easy-db-lab cassandra nt --hosts db0 tpstats
+
+# Execute CQL inline
+easy-db-lab cassandra cql "SELECT release_version FROM system.local"
+
+# Execute CQL from a file
+easy-db-lab cassandra cql --file schema.cql
+```
+
+**If `easy-db-lab cassandra cql` returns `No node was available` on a cluster where `nodetool status` shows all nodes UN**, the sidecar connection may not be ready yet. Wait 30 seconds and retry. If it continues to fail, run cqlsh directly via SSH:
+
+```bash
+ssh -i $(easy-db-lab ssh-key) ubuntu@$(easy-db-lab host db0) cqlsh
+```
+
+## Stress Testing
+
+The stress subcommand wraps `cassandra-easy-stress` running on Kubernetes on the app nodes.
+
+```bash
+# List available workloads
+easy-db-lab cassandra stress list
+
+# Show available field generators
+easy-db-lab cassandra stress fields
+
+# Get details on a workload
+easy-db-lab cassandra stress info KeyValue
+
+# Start a stress job (remaining args passed directly to cassandra-easy-stress)
+easy-db-lab cassandra stress start KeyValue -d 30m --threads 100
+
+# Named job with custom metric tags
+easy-db-lab cassandra stress start --name my-test --tags "run=baseline,nodes=3" \
+  KeyValue -d 1h --threads 200
+
+# Use a custom image
+easy-db-lab cassandra stress start --image ghcr.io/apache/cassandra-easy-stress:latest \
+  KeyValue -d 1h
+
+# Monitor running jobs
+easy-db-lab cassandra stress status
+easy-db-lab cassandra stress status --name my-test
+
+# View logs from a job
+easy-db-lab cassandra stress logs my-test
+easy-db-lab cassandra stress logs my-test --tail 100
+
+# Stop a specific job
+easy-db-lab cassandra stress stop my-test
+
+# Stop all stress jobs
+easy-db-lab cassandra stress stop --all
+
+# Force stop without confirmation
+easy-db-lab cassandra stress stop my-test --force
+```

--- a/plugins/easy-db-lab/references/clickhouse.md
+++ b/plugins/easy-db-lab/references/clickhouse.md
@@ -1,0 +1,57 @@
+# ClickHouse Workflow
+
+## Configure and Start
+
+```bash
+# Configure settings — run before first start
+easy-db-lab clickhouse init
+easy-db-lab clickhouse init --replicas-per-shard 3
+easy-db-lab clickhouse init --s3-cache 10Gi --s3-cache-on-write true
+easy-db-lab clickhouse init --s3-tier-move-factor 0.2
+
+# Deploy ClickHouse cluster to K8s
+easy-db-lab clickhouse start
+
+# Set number of replicas explicitly (default: number of db nodes)
+easy-db-lab clickhouse start --replicas 3
+
+# Wait up to custom timeout for pods to be ready (default: 300s)
+easy-db-lab clickhouse start --timeout 600
+
+# Skip waiting for pods
+easy-db-lab clickhouse start --skip-wait
+
+# Restore from a named backup on startup
+easy-db-lab clickhouse start --restore-from my-backup
+
+# Check cluster status
+easy-db-lab clickhouse status
+```
+
+## Backup and Restore
+
+```bash
+# Back up to the cluster S3 bucket
+easy-db-lab clickhouse backup my-backup
+
+# Back up in the background (returns immediately)
+easy-db-lab clickhouse backup my-backup --async
+
+# List available backups in S3
+easy-db-lab clickhouse list-backups
+
+# Restore from a named backup
+easy-db-lab clickhouse restore my-backup
+
+# Restore in the background
+easy-db-lab clickhouse restore my-backup --async
+```
+
+## Stop
+
+```bash
+easy-db-lab clickhouse stop
+
+# Force deletion without confirmation
+easy-db-lab clickhouse stop --force
+```

--- a/plugins/easy-db-lab/references/environment.md
+++ b/plugins/easy-db-lab/references/environment.md
@@ -1,0 +1,74 @@
+# Environment Overview
+
+## AWS
+
+All easy-db-lab environments run on AWS. If easy-db-lab does not have a built-in command for an operation, use the AWS CLI or other AWS tools directly. The cluster's region and S3 bucket are available via:
+
+```bash
+easy-db-lab aws region
+easy-db-lab aws s3-bucket
+```
+
+## Kubernetes (k3s)
+
+The cluster runs k3s (lightweight Kubernetes). ClickHouse and the observability stack run in k3s. Cassandra runs directly on EC2. OpenSearch and Spark are AWS-managed services that run outside the cluster.
+
+To connect to k3s, use the `kubeconfig` file in the workspace directory:
+
+```bash
+kubectl --kubeconfig kubeconfig get pods -A
+```
+
+Or export it for the session:
+
+```bash
+export KUBECONFIG=$(pwd)/kubeconfig
+kubectl get pods -A
+```
+
+## Observability Stack
+
+The following run in k3s and are part of every environment:
+
+- **Grafana** — dashboards and visualization
+- **VictoriaMetrics** — metrics storage and querying
+- **VictoriaLogs** — log storage and querying
+
+Use `easy-db-lab grafana update-config` to apply or refresh the full observability stack. Use `easy-db-lab logs` and `easy-db-lab metrics` for querying. If you need to interact with these directly (e.g. custom queries, imports), use `kubectl` with the `kubeconfig`.
+
+## Cassandra
+
+Cassandra runs directly on the EC2 instances, not in k3s. It is managed via `easy-db-lab cassandra` commands over SSH.
+
+Configuration overrides are stored in **`cassandra.patch.yaml`** in the workspace directory. This file contains only the settings that differ from the base config — it is merged server-side with the base `cassandra.yaml`. Edit this file and push it with:
+
+```bash
+easy-db-lab cassandra update-config cassandra.patch.yaml [--restart]
+```
+
+## OpenSearch
+
+OpenSearch runs as an AWS managed domain, not in k3s. It is provisioned and managed via `easy-db-lab opensearch` commands, which interact with AWS directly. See `opensearch.md` for the full workflow.
+
+## Spark
+
+Spark runs on AWS EMR, not in k3s. It is provisioned and managed via `easy-db-lab spark` commands. See `spark.md` for the full workflow.
+
+## SSH
+
+SSH access to all nodes is configured via **`sshConfig`** in the workspace directory. To use it directly:
+
+```bash
+ssh -F sshConfig db0
+ssh -F sshConfig app0
+```
+
+## After Running `up`
+
+After `easy-db-lab up` completes, always run:
+
+```bash
+source env.sh
+```
+
+This sets up local files including `sshConfig`. Without this step, SSH and other local tooling will not be configured correctly.

--- a/plugins/easy-db-lab/references/history.md
+++ b/plugins/easy-db-lab/references/history.md
@@ -1,0 +1,62 @@
+# history.md — Session Log
+
+`history.md` lives in the lab workspace directory and is a human-readable record of everything done to the environment. It is written for the operator and for clients reviewing the work later.
+
+## Create It Immediately
+
+The very first thing you do in any skill is create `history.md` if it does not exist, then open a new session entry:
+
+```markdown
+# Lab History
+
+## 2026-05-23 — <brief description of what this session is doing>
+```
+
+Do not wait. Create it before running any commands.
+
+## Update It Continuously
+
+After every command or observation, append an entry. Do not batch updates — write each one as it happens so the record is accurate even if the session is interrupted.
+
+```markdown
+### 10:34 Checked cluster status
+Both DCs up. dc1: 3 nodes, dc2: 3 nodes. All UN.
+
+### 10:36 Selected Cassandra 5.0 on dc1
+`easy-db-lab cassandra use 5.0` — completed successfully.
+
+### 10:41 Updated cassandra.patch.yaml on dc1
+Set num_tokens: 4, enabled trie memtables. Pushed and restarted.
+
+### 10:55 Started KeyValue stress test
+`cassandra stress start KeyValue -d 30m --threads 100 --name baseline`
+op/s: 24,500 — p99 read: 3.2ms, p99 write: 1.8ms
+```
+
+## What to Record
+
+- Every command run and whether it succeeded or failed
+- Key output: node counts, versions, IPs, op/s, latency percentiles, error messages
+- Configuration changes and what was changed
+- Decisions made and why
+- Anything unexpected or worth investigating
+- Results from stress tests and benchmarks
+
+## What to Skip
+
+- Routine status polls with no new information
+- Repeated identical commands with identical output
+
+## Format
+
+```markdown
+# Lab History
+
+## <YYYY-MM-DD> — <session goal>
+
+### <HH:MM> <action or observation>
+<what was done or found — one or two sentences>
+<key output or metrics if relevant>
+```
+
+If `history.md` already exists, read it first to understand the full context of what has been done to this environment before taking any action.

--- a/plugins/easy-db-lab/references/opensearch.md
+++ b/plugins/easy-db-lab/references/opensearch.md
@@ -1,0 +1,48 @@
+# OpenSearch Workflow
+
+OpenSearch runs as an AWS managed domain. Provisioning takes 10–30 minutes. It can be enabled at init time with `--opensearch.enable` or started independently.
+
+## Start
+
+```bash
+# Create an OpenSearch domain with defaults
+easy-db-lab opensearch start
+
+# Specify instance type, count, and storage
+easy-db-lab opensearch start \
+  --instance-type r5.large.search \
+  --instance-count 3 \
+  --ebs-size 100
+
+# Wait for the domain to become active before returning
+easy-db-lab opensearch start --wait
+```
+
+Or enable at `easy-db-lab init` time:
+```bash
+easy-db-lab init my-cluster --db 3 --app 1 --instance m5.2xlarge \
+  --opensearch.enable \
+  --opensearch.instance.type r5.large.search \
+  --opensearch.instance.count 3 \
+  --opensearch.version 2.11 \
+  --opensearch.ebs.size 100
+```
+
+## Status
+
+```bash
+# Check domain status
+easy-db-lab opensearch status
+
+# Output only the endpoint URL (useful for scripting)
+easy-db-lab opensearch status --endpoint
+```
+
+## Stop
+
+```bash
+easy-db-lab opensearch stop
+
+# Force deletion without confirmation
+easy-db-lab opensearch stop --force
+```

--- a/plugins/easy-db-lab/references/spark.md
+++ b/plugins/easy-db-lab/references/spark.md
@@ -1,0 +1,88 @@
+# Spark Workflow
+
+Spark runs on AWS EMR and can be provisioned on top of an existing easy-db-lab environment, or enabled at init time with `--spark.enable`.
+
+## Provision
+
+```bash
+# Provision Spark EMR cluster on existing environment
+easy-db-lab spark init
+
+# Specify instance types and worker count
+easy-db-lab spark init \
+  --master.instance.type m5.xlarge \
+  --worker.instance.type m5.2xlarge \
+  --worker.instance.count 3
+```
+
+Or enable at `easy-db-lab init` time:
+```bash
+easy-db-lab init my-cluster --db 3 --app 1 --instance m5.2xlarge \
+  --spark.enable \
+  --spark.master.instance.type m5.xlarge \
+  --spark.worker.instance.type m5.2xlarge \
+  --spark.worker.instance.count 3
+```
+
+## Submit Jobs
+
+```bash
+# Submit a job (--jar and --main-class are required)
+easy-db-lab spark submit \
+  --jar s3://bucket/my-job.jar \
+  --main-class com.example.Main
+
+# Pass arguments to the application
+easy-db-lab spark submit \
+  --jar s3://bucket/my-job.jar \
+  --main-class com.example.Main \
+  --args "--input s3://bucket/data --output s3://bucket/results"
+
+# Wait for job completion before returning
+easy-db-lab spark submit \
+  --jar my-job.jar \
+  --main-class com.example.Main \
+  --wait
+
+# Name the job, add Spark config and env vars
+easy-db-lab spark submit \
+  --jar my-job.jar \
+  --main-class com.example.Main \
+  --name my-job \
+  --conf spark.executor.memory=4g \
+  --conf spark.executor.cores=2 \
+  --env AWS_REGION=us-east-1
+```
+
+## Monitor and Manage Jobs
+
+```bash
+# List recent jobs (default: 10)
+easy-db-lab spark jobs
+easy-db-lab spark jobs --limit 20
+
+# Check status of the most recent job
+easy-db-lab spark status
+
+# Check status of a specific step
+easy-db-lab spark status --step-id s-XXXXXXXXXXXX
+
+# Verbose output (equivalent to aws emr describe-step)
+easy-db-lab spark status --step-id s-XXXXXXXXXXXX --verbose
+
+# View logs (defaults to most recent job, last 1d)
+easy-db-lab spark logs
+easy-db-lab spark logs --step-id s-XXXXXXXXXXXX --limit 200 --since 6h
+
+# Cancel the most recent running or pending job
+easy-db-lab spark stop
+
+# Cancel a specific step
+easy-db-lab spark stop --step-id s-XXXXXXXXXXXX
+```
+
+## Tear Down
+
+```bash
+easy-db-lab spark down
+```

--- a/plugins/easy-db-lab/skills/explore/SKILL.md
+++ b/plugins/easy-db-lab/skills/explore/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: explore
+description: Guided interactive mode for easy-db-lab — walks through provisioning if needed, then helps you run tests, stress workloads, and explore Cassandra, ClickHouse, Spark, and OpenSearch. The end-to-end starting point for a new lab session.
+argument-hint: [what you want to explore — e.g. "cassandra 5.0", "clickhouse analytics", "stress test comparison"]
+user-invocable: true
+---
+
+# Easy DB Lab — Explore
+
+You are an interactive guide for easy-db-lab sessions. You start by checking whether an environment exists, walk the user through provisioning if they don't have one yet, then help them run tests, stress workloads, and explore the cluster.
+
+## Environment
+
+Load `../../references/environment.md` for details on the AWS environment, k3s, observability stack, Cassandra config patches, SSH access, and the `source env.sh` requirement after `up`.
+
+## Session Log
+
+Load `../../references/history.md` for instructions on maintaining `history.md`. Read `history.md` if it exists before taking any action — it tells you what has already been done to this environment.
+
+## Step 1 — Check Environment State
+
+Run these two commands immediately when invoked, before answering any question or taking any action:
+
+**1. Discover the current command surface:**
+```bash
+easy-db-lab commands
+```
+Use this to confirm flag names, subcommand structure, and available options. Never guess flags.
+
+**2. Check the directory state:**
+```bash
+ls state.json 2>/dev/null && echo EXISTS || echo EMPTY
+```
+
+- **`state.json` exists** → a workspace is already initialized. Run `easy-db-lab status` immediately. The output tells you everything: node IPs, what's running (Cassandra, ClickHouse, Spark, OpenSearch, Grafana, VictoriaMetrics, etc.), and the current cluster state. Use this as ground truth before proceeding to Step 3.
+- **No `state.json`** → no environment has been provisioned yet. Proceed to Step 2.
+
+## Step 2 — Provision (if needed)
+
+If no environment exists, guide the user through provisioning before anything else. Ask:
+
+1. **What do you want to run?** (Cassandra, ClickHouse, Spark, OpenSearch, or a combination)
+2. **How many nodes?** (db nodes, app nodes)
+3. **Instance type?** (default: `m5.2xlarge`)
+4. **Single DC or multi-DC?**
+
+Then invoke `/easy-db-lab:provision` with those answers, or walk through the `easy-db-lab init` + `easy-db-lab up` flow directly if the user prefers to stay in this skill.
+
+Once provisioning completes and `source env.sh` has been run, continue to Step 3.
+
+## Step 3 — Guide Exploration and Testing
+
+With a live environment, ask the user what they want to do next. Suggest concrete options based on what's running:
+
+- Run a stress test (KeyValue, mixed read/write, etc.)
+- Check cluster health and observe metrics in Grafana
+- Run CQL queries or load sample data
+- Compare performance between configurations
+- Explore logs and observability tooling
+
+Stay interactive — confirm each action before running it, and summarize results so the user can decide what to try next.
+
+## Working Directory
+
+All `easy-db-lab` commands must be run from the **lab workspace directory** — the directory initialized with `easy-db-lab init`. This directory holds `state.json` and other cluster configuration files. If the user is not in a lab workspace directory, tell them to `cd` to it before proceeding.
+
+## Teardown
+
+```bash
+# Tear down (prompts for confirmation)
+easy-db-lab down
+
+# Preview what would be deleted
+easy-db-lab down --dry-run
+
+# Auto-approve
+easy-db-lab down --auto-approve
+
+# Back up ClickHouse data before teardown
+easy-db-lab down --clickhouse.backup
+```
+
+## Database Workflows
+
+Load the relevant reference file when the user is working with a specific database:
+
+- **Cassandra** → `../../references/cassandra.md`
+- **ClickHouse** → `../../references/clickhouse.md`
+- **Spark** → `../../references/spark.md`
+- **OpenSearch** → `../../references/opensearch.md`
+
+## Hosts and Networking
+
+```bash
+# List all hosts in the cluster
+easy-db-lab hosts
+
+# Show only db or app nodes as a comma-delimited list
+easy-db-lab hosts --db
+easy-db-lab hosts --app
+
+# Get IP for a specific host alias (db0, db1, app0, etc.)
+easy-db-lab ip db0
+easy-db-lab ip --private db0
+```
+
+## Observability
+
+```bash
+# Refresh the full observability stack (Grafana, VictoriaMetrics, VictoriaLogs)
+easy-db-lab grafana update-config
+
+# Query logs
+easy-db-lab logs query --source cassandra --since 1h
+easy-db-lab logs query --host db0 --grep "ERROR"
+easy-db-lab logs query --unit cassandra.service --since 30m
+easy-db-lab logs query --query '_msg:"OutOfMemory"'
+
+# Back up / restore logs
+easy-db-lab logs backup
+easy-db-lab logs ls
+
+# Back up / restore metrics
+easy-db-lab metrics backup
+easy-db-lab metrics ls
+```
+
+## Running Commands on Nodes
+
+```bash
+# Run a command on all cassandra nodes
+easy-db-lab exec run --type cassandra "nodetool compactionstats"
+
+# Run in parallel
+easy-db-lab exec run --type cassandra -p "df -h"
+
+# Run in background
+easy-db-lab exec run --bg --name my-job --type cassandra "some-long-running-command"
+
+# List running background jobs
+easy-db-lab exec list
+easy-db-lab exec list --type cassandra
+
+# Stop a background job
+easy-db-lab exec stop my-job
+```
+
+## MCP Server Integration
+
+easy-db-lab can run an MCP server for AI assistant integration:
+
+```bash
+easy-db-lab server --port 8080
+# Then register: claude mcp add --transport sse easy-db-lab http://127.0.0.1:8080/sse
+```
+
+## Guidance Principles
+
+1. **Always run `easy-db-lab commands` first** to get the current command surface before advising on flags.
+2. **Confirm the working directory** is a lab workspace before running any commands.
+3. **If `state.json` exists, run `easy-db-lab status`** before any action — it is the source of truth.
+4. **Use `--dry-run`** for `down` when the user isn't sure what will be deleted.
+5. **Prefer config patches** over full cassandra.yaml replacements — `write-config` + `update-config` is the safe workflow.
+6. **Use `--hosts`** when an operation should target specific nodes rather than the whole cluster.

--- a/plugins/easy-db-lab/skills/install/SKILL.md
+++ b/plugins/easy-db-lab/skills/install/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: install
+description: Install and operate easy-db-lab kits — databases, analytics engines, query engines, and apps. Each kit provides start, stop, backup, and restore commands.
+argument-hint: [kit name or "list" to see available kits]
+user-invocable: true
+---
+
+# Easy DB Lab — Install
+
+You are helping the user install and operate easy-db-lab kits.
+
+## Environment
+
+Load `../../references/environment.md` for details on the AWS environment, k3s, observability stack, SSH access, and the `source env.sh` requirement after `up`.
+
+## Session Log
+
+Load `../../references/history.md` for instructions on maintaining `history.md`. Read `history.md` if it exists before taking any action.
+
+## First Step — Get Current Command Surface
+
+```bash
+easy-db-lab commands
+```
+
+Use this to confirm the exact flags and subcommands for `install` and any installed kits. The interface may have changed since this skill was written.
+
+## What Is a Kit?
+
+A kit is an installable component that easy-db-lab can deploy and manage. Kits can be:
+
+- **Databases** — e.g. Cassandra, ClickHouse, PostgreSQL
+- **Analytics engines** — e.g. Spark
+- **Query engines** — e.g. Trino, Presto
+- **Apps** — workload generators, tools, or other applications
+
+## Installing a Kit
+
+```bash
+# List available kits
+easy-db-lab install --list
+
+# Install a kit
+easy-db-lab install <kit>
+```
+
+If the user doesn't know which kit they want, show them the list from `easy-db-lab install --list` and ask.
+
+## Operating an Installed Kit
+
+Once a kit is installed, it provides its own subcommands:
+
+```bash
+easy-db-lab <kit> start
+easy-db-lab <kit> stop
+easy-db-lab <kit> backup
+easy-db-lab <kit> restore
+```
+
+Always run `easy-db-lab commands` first to see the exact flags each kit's subcommands accept — they vary by kit.
+
+## Workflow
+
+1. Confirm the environment is up (`state.json` exists, `easy-db-lab status` shows nodes ready)
+2. List available kits if the user is unsure what to install
+3. Install the kit
+4. Start the kit
+5. Verify it's running via `easy-db-lab <kit> status` (if available) or `easy-db-lab status`
+
+## Guidance
+
+- A kit may depend on the cluster being fully up before it can be installed — check `easy-db-lab status` if install fails.
+- Backup and restore behavior varies by kit — always check the flags from `easy-db-lab commands` before running them.

--- a/plugins/easy-db-lab/skills/plan/SKILL.md
+++ b/plugins/easy-db-lab/skills/plan/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: plan
+description: Help the user design a lab workflow — ask what they want to accomplish, work through the steps together, and write the result to plan.md.
+argument-hint: [what you want to accomplish — e.g. "benchmark Cassandra 5.0 vs 4.1", "test ClickHouse with S3 tiering"]
+user-invocable: true
+---
+
+# Easy DB Lab — Plan
+
+You are helping the user design a lab workflow. Your job is to ask the right questions, help them think through the steps, and produce a clear `plan.md` they can follow.
+
+## Environment
+
+Load `../../references/environment.md` for details on the AWS environment, k3s, observability stack, Cassandra config patches, SSH access, and the `source env.sh` requirement after `up`.
+
+## Session Log
+
+Load `../../references/history.md` for instructions on maintaining `history.md`. Read `history.md` if it exists — past actions and observations should inform the plan.
+
+## Discover the Command Surface First
+
+Before writing any plan step that uses `easy-db-lab`, run:
+
+```bash
+easy-db-lab commands
+```
+
+Use this output as the authoritative source for flag names, subcommand structure, and available options. Never guess flags — if a flag isn't in the output of `easy-db-lab commands`, do not use it.
+
+## Step 1 — Understand the Goal
+
+Ask the user what they want to accomplish. If they've provided an argument, use that as the starting point. Probe for:
+
+- **What are they testing or benchmarking?** (a specific database, a config change, a workload pattern)
+- **What does success look like?** (metrics, observations, a pass/fail condition)
+- **Are there constraints?** (time, cost, instance types, existing infrastructure)
+
+Ask one question at a time. Don't move on until you have a clear goal.
+
+## Step 2 — Identify the Components
+
+Based on the goal, determine which components are needed. Ask about each that's relevant:
+
+**Infrastructure:**
+- How many db nodes? What instance type?
+- Are app/stress nodes needed? How many?
+- Any availability zone requirements?
+
+**Instance type and storage — ask explicitly:**
+- If the user picks an instance type with local NVMe (e.g. `i4i.xlarge`, `im4gn.xlarge`), no EBS config is needed.
+- If the user picks an instance type without local NVMe (e.g. `m5.xlarge`, `r6i.xlarge`, `c6i.xlarge`), EBS **must** be configured. Ask which volume type:
+  - **gp3** — general purpose SSD, good default for most workloads (default if they don't specify)
+  - **io2** — high-IOPS SSD, for latency-sensitive workloads requiring provisioned IOPS
+  Present these as a menu. If they choose io2, also ask for the IOPS value.
+- If the user doesn't specify an instance type, recommend `i4i.xlarge` for database nodes (local NVMe, no EBS needed).
+
+**Databases** — load the relevant reference file(s) for accurate command details:
+- Cassandra → `../../references/cassandra.md`
+- ClickHouse → `../../references/clickhouse.md`
+- Spark → `../../references/spark.md`
+- OpenSearch → `../../references/opensearch.md`
+
+**AWS credentials:**
+- Ask which `AWS_PROFILE` to use for any AWS CLI commands in this plan. Do not assume or encode a default — always ask.
+
+**Sidecar image (bulk import workflows only):**
+- If the plan involves bulk SSTable import (e.g. IAM Bulk Writer, Spark), ask whether a custom sidecar image is needed. If yes, get the full image URI now — it must be passed at `cassandra start` time via `--sidecar-image`.
+
+**Workload:**
+- What stress workload? (for Cassandra: `easy-db-lab cassandra stress list`)
+- How long should the test run? How many threads?
+- Any custom tags for metrics?
+
+**Observability:**
+- Will Grafana be used to monitor? (it's part of the default stack)
+- Are log queries needed during the test?
+
+## Step 3 — Build the Plan
+
+Once you have enough information, construct a step-by-step plan. Each step should be a concrete action with the exact command to run. Group steps logically:
+
+1. Provision the environment
+2. Configure the database(s)
+3. Run the workload or test
+4. Observe / collect results
+5. Tear down (if applicable)
+
+## Step 4 — Write plan.md
+
+Write the plan to `plan.md` in the current directory. Format:
+
+```markdown
+# Lab Plan: <goal>
+
+## Goal
+<one or two sentences describing what this plan accomplishes and what success looks like>
+
+## Environment
+<summary of infrastructure: nodes, instance types, storage>
+
+## Steps
+
+### 1. <Step name>
+<brief description>
+\```bash
+<command>
+\```
+
+### 2. <Step name>
+...
+
+## Notes
+<any caveats, things to watch for, or follow-up ideas>
+```
+
+Show the user the plan before writing it and ask for confirmation. After writing, tell them to run `/easy-db-lab:run` to execute it.

--- a/plugins/easy-db-lab/skills/provision/SKILL.md
+++ b/plugins/easy-db-lab/skills/provision/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: provision
+description: Provision a new easy-db-lab environment — single DC or multi-DC. Handles infrastructure only: instances, networking, VPC peering, and security groups.
+argument-hint: [cluster name and options — e.g. "3 node cluster", "2 DCs, 3 nodes each"]
+user-invocable: true
+---
+
+# Easy DB Lab — Provision
+
+You are provisioning the AWS infrastructure for an easy-db-lab environment. This skill covers instances and networking only — database setup and configuration is done separately with `/easy-db-lab:explore`.
+
+## Environment
+
+Load `../../references/environment.md` for details on the AWS environment, k3s, SSH access, and the `source env.sh` requirement after `up`.
+
+## Session Log
+
+Load `../../references/history.md` for instructions on maintaining `history.md`. Read `history.md` if it exists before taking any action.
+
+## Discover the Command Surface First
+
+Before building any `easy-db-lab` command, run:
+
+```bash
+easy-db-lab commands
+```
+
+Use this output as the authoritative source for flag names, subcommand structure, and available options. Never guess flags — if a flag isn't in the output of `easy-db-lab commands`, do not use it.
+
+## Step 1 — Determine Topology
+
+Ask the user:
+- **Single DC or multi-DC?**
+- **How many DCs?** (if multi-DC)
+- **Cluster/DC name(s)** — used to tag AWS resources
+- **Number of db nodes** (`--db`) — no default, ask the user
+- **Number of app nodes** (`--app`) — needed for stress testing; 0 if not needed
+- **Expiry** (`--until`) — optional
+- **Availability zones** (`--azs`) — optional
+
+For multi-DC, each DC lives in its own subdirectory (e.g. `dc1/`, `dc2/`). All `easy-db-lab` commands for a DC must be run from its directory.
+
+For **multi-DC only**, assign non-overlapping CIDR blocks (must be /20 or larger (e.g. /20, /19, /16)):
+- dc1: `10.0.0.0/16` (default)
+- dc2: `10.1.0.0/16`
+- dc3: `10.2.0.0/16`
+- etc.
+
+### Instance Selection
+
+If the user has not specified instance types, guide them through three choices — one at a time.
+
+**1. Architecture**
+
+```
+1) x86_64
+2) arm64 (Graviton — better price/performance)
+```
+
+**2. Storage**
+
+```
+1) Local NVMe (instance storage) — lower latency, no extra cost, lost on stop
+2) EBS — persistent, flexible size/IOPS, small added cost
+```
+
+If the user chooses EBS, ask which volume type (default: gp3):
+```
+1) gp3 (recommended) — configurable IOPS and throughput, best value
+2) io2 — provisioned IOPS SSD, for latency-sensitive workloads
+```
+
+Then ask:
+- **Size** (GB) — no default, ask the user
+- **IOPS** — only for gp3 and io2; gp3 default is 3000, io2 ask the user
+- **Throughput** (MB/s) — only for gp3; default 125 MB/s
+
+**3. Size**
+
+| # | Size   | x86 / Local NVMe  | x86 / EBS      | arm64 / Local NVMe | arm64 / EBS    |
+|---|--------|-------------------|----------------|--------------------|----------------|
+| 1 | Small  | i4i.xlarge        | m5.xlarge      | im4gn.xlarge       | m7g.xlarge     |
+| 2 | Medium | i4i.2xlarge       | m5.2xlarge     | im4gn.2xlarge      | m7g.2xlarge    |
+| 3 | Large  | i4i.4xlarge       | m5.4xlarge     | im4gn.4xlarge      | m7g.4xlarge    |
+| 4 | Other  | (user specifies)  | (user specifies)| (user specifies)  | (user specifies)|
+
+For EBS: `--ebs.iops` and `--ebs.throughput` apply to gp3, io1, and io2. `--ebs.throughput` applies to gp3 only.
+
+For app/stress nodes, ask if they want a different instance type or the same as db nodes.
+
+## Step 2 — Check Existing State
+
+For each DC directory, check whether it has already been provisioned:
+
+```bash
+ls <dc-dir>/state.json 2>/dev/null && echo EXISTS || echo EMPTY
+```
+
+If `state.json` exists in any DC directory, run `easy-db-lab status` from that directory and show the user before proceeding. Do not re-provision without explicit confirmation.
+
+## Step 3 — Init and Up Each DC
+
+For multi-DC, init and up all DCs in parallel — each in its own shell:
+
+```bash
+(mkdir -p dc1 && cd dc1 && easy-db-lab init dc1 --db 3 --app 1 --instance m5.2xlarge --cidr 10.0.0.0/16 --up) &
+(mkdir -p dc2 && cd dc2 && easy-db-lab init dc2 --db 3 --app 1 --instance m5.2xlarge --cidr 10.1.0.0/16 --up) &
+wait
+```
+
+Then source `env.sh` in each DC directory after all are up:
+
+```bash
+cd dc1 && source env.sh && cd ..
+cd dc2 && source env.sh && cd ..
+```
+
+For single DC, no `--cidr` is required and no subdirectory is needed unless the user prefers it.
+
+## Step 4 — VPC Peering (multi-DC only)
+
+Run `easy-db-lab status` in each DC directory — the output contains the VPC ID, node IPs, region, and everything else needed.
+
+```bash
+cd dc1 && easy-db-lab status && cd ..
+cd dc2 && easy-db-lab status && cd ..
+```
+
+Create and accept the peering connection:
+
+```bash
+REGION=$(cd dc1 && easy-db-lab aws region)
+
+PEER_ID=$(aws ec2 create-vpc-peering-connection \
+  --vpc-id <dc1-vpc-id> \
+  --peer-vpc-id <dc2-vpc-id> \
+  --region $REGION \
+  --query 'VpcPeeringConnection.VpcPeeringConnectionId' \
+  --output text)
+
+aws ec2 accept-vpc-peering-connection \
+  --vpc-peering-connection-id $PEER_ID \
+  --region $REGION
+```
+
+For 3+ DCs, peer each pair: dc1↔dc2, dc1↔dc3, dc2↔dc3, etc.
+
+Add routes in each VPC's route tables:
+
+```bash
+aws ec2 create-route \
+  --route-table-id <dc1-route-table-id> \
+  --destination-cidr-block 10.1.0.0/16 \
+  --vpc-peering-connection-id $PEER_ID \
+  --region $REGION
+
+aws ec2 create-route \
+  --route-table-id <dc2-route-table-id> \
+  --destination-cidr-block 10.0.0.0/16 \
+  --vpc-peering-connection-id $PEER_ID \
+  --region $REGION
+```
+
+Use `aws ec2 describe-route-tables --filters "Name=vpc-id,Values=<vpc-id>"` to find route table IDs.
+
+## Step 5 — Update Security Groups (multi-DC only)
+
+```bash
+aws ec2 describe-security-groups \
+  --filters "Name=vpc-id,Values=<vpc-id>" \
+  --region $REGION
+
+aws ec2 authorize-security-group-ingress \
+  --group-id <dc1-sg-id> \
+  --protocol -1 \
+  --cidr 10.1.0.0/16 \
+  --region $REGION
+
+aws ec2 authorize-security-group-ingress \
+  --group-id <dc2-sg-id> \
+  --protocol -1 \
+  --cidr 10.0.0.0/16 \
+  --region $REGION
+```
+
+Repeat for each DC pair.
+
+## Step 6 — Verify
+
+Run `easy-db-lab status` from each DC directory and confirm all nodes are reachable:
+
+```bash
+cd dc1 && easy-db-lab status && cd ..
+cd dc2 && easy-db-lab status && cd ..
+```
+
+Infrastructure is ready. Use `/easy-db-lab:explore` for database setup and configuration.

--- a/plugins/easy-db-lab/skills/run/SKILL.md
+++ b/plugins/easy-db-lab/skills/run/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: run
+description: Execute a plan.md step by step in a lab workspace. Reads the plan, confirms with the user at each step, and updates history.md as work proceeds.
+argument-hint: "optional — step number to start from, e.g. 'start from step 3'"
+user-invocable: true
+---
+
+# Easy DB Lab — Run Plan
+
+You execute a `plan.md` in the current lab workspace, one step at a time.
+
+## Environment
+
+Load `../../references/environment.md` for details on the AWS environment, k3s, SSH access, and the `source env.sh` requirement after `up`.
+
+## Session Log
+
+Load `../../references/history.md` for instructions on maintaining `history.md`. Read `history.md` if it exists before taking any action — it tells you what has already been done.
+
+## Discover the Command Surface First
+
+Before executing any `easy-db-lab` command, run:
+
+```bash
+easy-db-lab commands
+```
+
+Use this output as the authoritative source for flag names and available options. Never guess flags.
+
+## Before Starting
+
+1. **Verify the workspace:**
+   ```bash
+   ls plan.md 2>/dev/null && echo EXISTS || echo MISSING
+   ls state.json 2>/dev/null && echo EXISTS || echo EMPTY
+   ```
+
+   - If `plan.md` is missing, tell the user to create one with `/easy-db-lab:plan` first.
+   - If `state.json` exists, run `easy-db-lab status` to confirm the current cluster state.
+
+2. **Read `plan.md`** — display a numbered summary of all steps to the user before executing anything.
+
+3. **If the user specified a starting step** (e.g. "start from step 3"), confirm which step that is and skip to it.
+
+## Execution Loop
+
+For each step in the plan, in order:
+
+**1. Show the step**
+
+Display the full step text and ask: "Ready to execute this step?"
+
+Wait for the user to confirm before proceeding.
+
+**2. Execute**
+
+Run the required `easy-db-lab` commands (or AWS CLI, kubectl, etc.) for the step. Show the output.
+
+**3. Verify**
+
+After each step, confirm it succeeded:
+- For `easy-db-lab up`: check that nodes are reachable via `easy-db-lab status`
+- For cassandra start: check cluster health via `easy-db-lab cassandra status` or `nodetool status`
+- For other steps: use the most appropriate check given the operation
+
+**4. Update history.md**
+
+Record what was done, the outcome, and any relevant output. See `../../references/history.md` for format.
+
+**5. Proceed**
+
+Ask: "Step N complete. Continue to step N+1?" before moving on.
+
+## Pausing and Resuming
+
+If the user asks to stop, record progress in `history.md` (last completed step + state) so the next session can resume cleanly.
+
+When invoked again, read `history.md` to determine where to resume, then confirm with the user before continuing.
+
+## Error Handling
+
+If a step fails:
+1. Show the error clearly.
+2. Do not proceed to the next step.
+3. Diagnose the failure — check logs, status, or node health as appropriate.
+4. Propose a fix and wait for user approval before retrying.
+5. Record the failure and resolution in `history.md`.
+
+## Database Workflows
+
+Load the relevant reference file when a step involves a specific database:
+
+- **Cassandra** → `../../references/cassandra.md`
+- **ClickHouse** → `../../references/clickhouse.md`
+- **Spark** → `../../references/spark.md`
+- **OpenSearch** → `../../references/opensearch.md`


### PR DESCRIPTION
## Summary

- Adds the `easy-db-lab` plugin with three skills: `/easy-db-lab:provision`, `/easy-db-lab:plan`, and `/easy-db-lab:exec`
- `provision` handles single and multi-DC environments including VPC peering, security group rules, and Cassandra seed coordination across DCs
- `plan` interactively helps the user design a lab workflow and writes it to `plan.md`
- `exec` is the general-purpose skill for operating a running environment
- Reference files cover Cassandra, ClickHouse, Spark, and OpenSearch workflows, plus shared environment context (AWS, k3s, observability stack) and session history tracking in `history.md`