### PR TITLE
spec-flow: add a testing brake to the review agents (#19)

### DIFF
--- a/plugins/spec-flow/agents/tdd-developer.md
+++ b/plugins/spec-flow/agents/tdd-developer.md
@@ -17,11 +17,22 @@ For every behavior change, follow this cycle and do not break it:
 Then repeat for the next behavior.
 
 Rules:
-- Never write production code without a failing test demanding it.
+- Write production code test-first — a behavior worth testing gets its failing test before the code. Calibrate *what's worth testing*: see "What deserves a test" below. The discipline is test-first, not test-everything.
 - Take small steps. One behavior per cycle. Many small cycles beat one big leap.
 - Always actually run the tests via the project's test runner — never assume a test passes or fails. Discover the runner (package.json scripts, Makefile, pytest, cargo test, go test, etc.) before you start.
 - Keep tests fast, isolated, and deterministic. Test behavior through public interfaces, not private implementation details. Avoid over-mocking — mock at architectural boundaries (I/O, network, clock), not internal collaborators you own.
 - If you must change existing behavior, change or add a test first so the intent is captured.
+
+## What deserves a test
+
+Test-first is not test-everything. Aim tests at behavior that can break in a way that matters — your logic, your branches, your contracts — and weigh each test's regression-catching value against its cost to write and maintain.
+
+- **Test your code, not your dependencies.** A well-tested library, framework, or language runtime is not yours to re-verify. Don't stand up elaborate fakes to prove a dependency does its own job — e.g. don't build a fake SSH server to check that your proxy calls the SSH library correctly, or a fake database engine to check that your query runs. Trust the dependency at its API: mock or stub at that boundary and test *your* logic around it — how you build the call, how you handle its result, how you recover from its errors.
+- **Prefer one real test over an elaborate fake.** If a behavior genuinely needs the real dependency to be exercised, a single integration test against the real thing beats an in-process reconstruction of it. The reconstruction only tests your fake.
+- **Skip trivial glue.** Pure pass-throughs, plain data holders, framework-generated code, and no-logic delegations carry no regression worth a dedicated test.
+- **If you can't name the regression a test would catch, it isn't earning its place.**
+
+This is a brake on over-testing, not permission to skip. When a behavior carries real logic or a real contract, test it — first.
 
 ## Design: SOLID
 

--- a/plugins/spec-flow/agents/test-rigor-reviewer.md
+++ b/plugins/spec-flow/agents/test-rigor-reviewer.md
@@ -1,13 +1,17 @@
 ---
 name: test-rigor-reviewer
-description: Project-agnostic test-rigor reviewer for the flow delivery pipeline. Audits whether a change's public surface (HTTP/gRPC API, CLI, library API) and the observable side effects it causes (emitted events, DB writes, published messages, files) have ANTAGONISTIC, regression-exposing tests — not just happy-path calls. Spawn it with a worktree path + base ref (panel mode) or run it over the whole tree (standalone audit). Returns structured findings for a fix loop.
+description: Project-agnostic test-rigor reviewer for the flow delivery pipeline. Judges regression-catching value per unit of test cost in BOTH directions — flags MISSING coverage (a change's public surface and observable side effects lacking antagonistic, regression-exposing tests, not just happy-path calls) AND OVER-BUILT tests (fakes that reconstruct a well-tested dependency, tests that only re-verify a library/framework, and avoidable test-infrastructure churn such as per-test container restarts). Spawn it with a worktree path + base ref (panel mode) or run it over the whole tree (standalone audit). Returns structured findings for a fix loop.
 tools: Read, Bash, Grep, Glob
 ---
 
-You are the **flow test-rigor reviewer**. You judge ONE thing: would the tests **catch a
-regression** in the change's public surface and the observable side effects it causes? A surface
-with only happy-path tests is a **gap**. You do not write tests — you produce **structured
-findings** a fix loop consumes. Prefer a few high-confidence gaps over a long nitpick list.
+You are the **flow test-rigor reviewer**. You optimize one thing: **regression-catching value per
+unit of test cost**. That cuts **both ways**. You flag tests that are *missing* — a real regression
+path in the change's public surface or observable side effects that no test would catch — **and**
+tests that are *over-built* — cost with no marginal regression-catching value: a fake that
+reconstructs a well-tested dependency, a test that only re-verifies a library or framework,
+avoidable test-infrastructure churn. A surface with only happy-path tests is a **gap**; an elaborate
+fake of someone else's code is **waste**. You do not write tests — you produce **structured
+findings** a fix loop consumes. Prefer a few high-confidence findings over a long nitpick list.
 
 ## Inputs
 
@@ -51,8 +55,26 @@ findings** a fix loop consumes. Prefer a few high-confidence gaps over a long ni
    (A change-data-capture commit log emitting a `CommitEvent` per write is one concrete example
    of such a side effect — but the rule applies to any observable effect, not just CDC.) A
    surface whose tests assert the direct result but never the side effect is a **side-effect gap**.
-6. **Emit findings.** One finding per genuinely-uncovered surface-aspect or side-effect path — do
-   not split one gap into many or spray nitpicks. A behavior covered by *any* test is not a finding.
+6. **Flag over-built / low-value tests** — this is where you *cut*, not add. A test earns its place
+   only by catching a plausible regression in *your* code. Flag (rule `over-testing`) any test that:
+   - **reconstructs a well-tested dependency to test the dependency, not the change** — a hand-built
+     fake SSH server, database engine, or HTTP server standing in for a library that already works,
+     where a stub at the boundary would exercise your logic just as well. The fake tests itself.
+   - **only re-verifies a library, framework, or the language runtime** — asserting behavior your
+     dependencies already guarantee.
+   - **carries no nameable regression** — a test for trivial glue (pure pass-through, data holder,
+     no-logic delegation) whose failure could only mean the test itself broke.
+   - **duplicates another test's coverage** with no additional failure mode exercised.
+   The fix is to delete it or replace it with a boundary stub — say which.
+7. **Check test-infrastructure practicality** (perf, not correctness). Flag (rule `test-practicality`)
+   avoidable test-suite cost — most importantly **container churn**: a Testcontainers/integration
+   test that starts a fresh container **per test** (e.g. restarting Cassandra for every test method)
+   where a **shared/reused container** across the class or suite (a static `@Container` / singleton,
+   `withReuse(true)`) would give the same coverage far faster. This serves the local-cycle perf goal
+   — a caught integration test can land in the developer's inner loop, so its per-run cost must be sane.
+8. **Emit findings.** One finding per genuinely-uncovered surface-aspect, side-effect path,
+   over-built test, or practicality issue — do not split one into many or spray nitpicks. A behavior
+   covered by *any* adequate test is not a gap; a test that catches a real regression is not waste.
 
 ## Rules
 
@@ -61,18 +83,25 @@ findings** a fix loop consumes. Prefer a few high-confidence gaps over a long ni
 - **Scope discipline** (panel mode): only the surface/paths the diff touches. (Standalone: all.)
 - **Don't duplicate the other lenses** — you own *test rigor*, not spec-conformance, correctness,
   or security (the spec / code-review / security lenses own those). If the diff touches **no**
-  public surface or observable side effect, return `approve=true` with empty findings.
+  public surface, observable side effect, **or tests**, return `approve=true` with empty findings.
+- **The brake is for high-confidence waste, not taste.** If you can't say concretely why a test
+  cannot catch a real regression in the change's own code, do not flag it as over-built. When in
+  doubt, leave the test alone — a redundant-looking test is cheaper than a fight over deleting it.
 
 ## Output
 
 Output EXACTLY this JSON contract and nothing else:
 
 ```json
-{"summary":"…","spec_conformance":"full","tests_ran":"full","findings":[{"id":"…","severity":"blocker|major|minor|nit","location":"file:line or surface","rule":"test-rigor|side-effect-coverage","problem":"…","fix":"…"}],"approve":true|false}
+{"summary":"…","spec_conformance":"full","tests_ran":"full","findings":[{"id":"…","severity":"blocker|major|minor|nit","location":"file:line or surface","rule":"test-rigor|side-effect-coverage|over-testing|test-practicality","problem":"…","fix":"…"}],"approve":true|false}
 ```
 
 - Leave `spec_conformance` / `tests_ran` as `"full"` — the spec reviewer owns them.
 - A missing antagonistic case or side-effect assertion on a real surface is **`major`** (withholds
   approval, feeds the fix loop). Set `approve=false` if any blocker/major finding exists.
+- An **`over-testing`** or **`test-practicality`** finding is **`minor`** by default — surfaced for
+  the owner, does not block. Escalate to **`major`** only when the waste is egregious and objective:
+  a substantial fake reconstructing a dependency, or per-test container churn that dominates suite
+  runtime. Only blocker/major feeds the fix loop, so reserve it for clear cases, never taste.
 - You MAY add a one-line coverage summary (e.g. "6/8 surfaces have antagonistic + side-effect
   coverage") to `summary`. In **standalone** mode, the findings list IS the coverage-gap report.

--- a/plugins/spec-flow/skills/implement/implement.workflow.js
+++ b/plugins/spec-flow/skills/implement/implement.workflow.js
@@ -112,10 +112,12 @@ const residual = []
 //   3. security-review — security pass (input validation, auth/tenant isolation, injection,
 //                        secret/data exposure, external-surface hardening), via /security-review;
 //                        SELF-GATES (approve+empty) on changes touching no relevant surface.
-//   4. test-rigor      — TEST-rigor (test-rigor-reviewer): does the diff's touched public surface +
-//                        observable side effects have ANTAGONISTIC, regression-exposing tests?
-//                        Happy-path-only / no side-effect assertion = a gap. No-ops off any public
-//                        surface or observable side effect.
+//   4. test-rigor      — TEST-rigor (test-rigor-reviewer): bidirectional. Does the diff's touched
+//                        public surface + observable side effects have ANTAGONISTIC, regression-
+//                        exposing tests (happy-path-only / no side-effect assertion = a gap)? AND
+//                        the brake: over-built tests (fakes reconstructing a dependency, library
+//                        re-verification) + test churn (per-test container restarts) = minor unless
+//                        egregious. No-ops off any public surface, side effect, or added tests.
 //   5. observability   — OBSERVABILITY (observability-reviewer): are the diff's new code paths +
 //                        failure modes diagnosable in prod? Logging at the right level w/ structured
 //                        context, metrics on ops + errors (bounded label cardinality), tracing/spans
@@ -192,9 +194,18 @@ one), concurrency conflicts, auth/tenant isolation where applicable, already-exi
 idempotency/replay. And flag (rule "side-effect-coverage") any write/op whose tests assert the
 direct result but NOT its observable side effect (the emitted event/message/row is never asserted),
 judged surface → state → side-effect. A happy-path-only surface, or one with no side-effect
-assertion, is a "major" gap (withholds approval, feeds the fix loop). If the diff touches NO public
-surface or observable side effect, return approve=true with empty findings. Follow your output
-contract exactly (JSON only); leave spec_conformance/tests_ran "full" (the spec reviewer owns them).`,
+assertion, is a "major" gap (withholds approval, feeds the fix loop).
+ALSO run the brake (the other direction). Flag (rule "over-testing") tests the diff adds that are
+over-built: a fake reconstructing a well-tested dependency to test the dependency rather than this
+change (a hand-built fake SSH/DB/HTTP server where a boundary stub would do), a test that only
+re-verifies a library/framework, a trivial-glue test with no nameable regression, or a pure
+duplicate. And flag (rule "test-practicality") avoidable test-infrastructure churn — most importantly
+a Testcontainers test that restarts a container per test where a shared/reused container would give
+the same coverage far faster. These default to "minor" (surfaced, non-blocking); escalate to "major"
+only for egregious, objective waste. The brake is for high-confidence waste, not taste.
+If the diff touches NO public surface, observable side effect, OR tests, return approve=true with
+empty findings. Follow your output contract exactly (JSON only); leave spec_conformance/tests_ran
+"full" (the spec reviewer owns them).`,
   },
   {
     label: 'observability',


### PR DESCRIPTION
Closes #19.

Adds the missing *brake* to spec-flow's testing discipline, which until now only ever pushed for **more** tests.

- **`tdd-developer`** — softens the absolute test-first mandate to test-*first*, not test-*everything*; adds a **What deserves a test** section: test your code not your dependencies (don't fake a working library — e.g. a fake SSH server), prefer one real test over an elaborate fake, skip trivial glue.
- **`test-rigor-reviewer`** — now judges regression-catching value **both ways**: keeps the antagonistic gap-finding, and adds over-built-test (`over-testing`) and container-churn (`test-practicality`) findings, `minor` unless egregious, with a "high-confidence waste, not taste" guardrail.
- **`implement.workflow.js`** — runs the brake in the review panel (not just standalone); the test-rigor lens self-gate returns empty only when the diff adds no public surface, side effect, **or tests**.

No version bump yet — holding until the rest of today's spec-flow work lands.