### PR TITLE
New skill: walkthrough — agent-authored code walkthrough & analysis presentations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,7 +28,7 @@
     {
       "name": "review-tools",
       "source": "./plugins/review-tools",
-      "description": "Render an IDE-style single-page HTML view of a diff, a GitHub issue plus everything linked to it, or docs — standalone, no other plugin required",
+      "description": "Render a change or a subsystem as one self-contained HTML page — `explain` for an IDE-style view of a diff, a GitHub issue plus everything linked to it, or docs; `walkthrough` for a diagram-first, ordered-step presentation — standalone, no other plugin required",
       "category": "workflow"
     }
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 cassandra-upstream/
 /tests
 .DS_Store
+__pycache__/
 .claude/worktrees/
 .spec-flow/

--- a/README.md
+++ b/README.md
@@ -349,11 +349,17 @@ See [`plugins/spec-flow/docs/workflow.md`](plugins/spec-flow/docs/workflow.md) f
 
 ### review-tools
 
-Render an IDE-style single-page HTML view — a file tree on the left (code diffs and plain files in
-one panel, docs/issue text in another, whichever's non-empty), a code/diff/doc editor top-right,
-and an explanation pane bottom-right — of a git diff, a GitHub issue plus everything linked to it,
-project docs, or any mix. Self-contained output, no server, no CDN, opens over `file://`. Standalone
-— no other plugin required, useful in any repo.
+Two skills that render a change or a subsystem as one self-contained HTML page — no server, no
+CDN, opens over `file://`. Standalone — no other plugin required, useful in any repo.
+
+- **`explain`** — an IDE-style view: a file tree on the left (code diffs and plain files in one
+  panel, docs/issue text in another, whichever's non-empty), a code/diff/doc editor top-right, and
+  an explanation pane bottom-right — of a git diff, a GitHub issue plus everything linked to it,
+  project docs, or any mix.
+- **`walkthrough`** — a diagram-first, ordered-step presentation for when there is no diff to open:
+  how something works, a technical-debt review, an areas-for-improvement pass, recommendations, or
+  a performance analysis. You investigate and author every word; the renderer turns it into a
+  presentation — vertical scroll by default, one button away from horizontal slide-by-slide.
 
 Claude Code:
 
@@ -366,6 +372,7 @@ Claude Code:
 | Skill | Purpose |
 |-------|---------|
 | `/explain <issue-N \| base-ref> [docs...]` | Render the HTML view — an issue (body, comments, related/linked issues), a diff, docs, or any combination |
+| `/walkthrough [what to walk through]` | Render a diagram-first, ordered-step presentation — how something works, a tech-debt review, recommendations, a performance analysis |
 
 If the [`spec-flow`](#spec-flow) plugin is also installed, its `activate`/`implement` skills call
 `explain` automatically at both owner seams once `SPEC_FLOW_SEAM_VIEW=explain` is set (via
@@ -373,7 +380,8 @@ If the [`spec-flow`](#spec-flow) plugin is also installed, its `activate`/`imple
 integration is optional and one-directional; `review-tools` has no dependency on spec-flow.
 
 See [`plugins/review-tools/skills/explain/SKILL.md`](plugins/review-tools/skills/explain/SKILL.md)
-for the full CLI and manifest schema.
+and [`plugins/review-tools/skills/walkthrough/SKILL.md`](plugins/review-tools/skills/walkthrough/SKILL.md)
+for the full CLI and manifest schemas.
 
 ## License
 

--- a/openspec/changes/issue-42/.openspec.yaml
+++ b/openspec/changes/issue-42/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/issue-42/ac-coverage.md
+++ b/openspec/changes/issue-42/ac-coverage.md
@@ -1,0 +1,18 @@
+| Source | Requirement | Covering scenario(s) | Status |
+|--------|-------------|----------------------|--------|
+| AC | Valid manifest (diagram + N steps) → one self-contained HTML file, diagram before all steps, steps in order | `walkthrough: Valid manifest renders in order` | ✅ Covered |
+| AC | Rendered file has no `http://`, `https://`, or `fetch(` | `walkthrough: No network references in rendered output` | ✅ Covered |
+| AC | Presentation defaults to vertical-scroll layout | `walkthrough: Default layout is vertical` | ✅ Covered |
+| AC | Runtime toggle switches to horizontal and back, no regeneration, single artifact | `walkthrough: Toggle switches to horizontal and back` | ✅ Covered |
+| AC | Code excerpts + `file:line` references render inside their step | `walkthrough: Excerpt and reference render together` | ✅ Covered |
+| AC | Same manifest schema/renderer for non-"how it works" walkthroughs (tech-debt/improvements/recommendations/performance) | `walkthrough: Non-"how it works" walkthrough uses the same renderer` | ✅ Covered |
+| AC | Optional `kind` field renders a badge; omitted → no badge | `walkthrough: Kind present renders a badge`, `walkthrough: Kind omitted renders no badge` | ✅ Covered |
+| AC | No/empty manifest → fails loudly, non-zero exit, no empty presentation | `walkthrough: No manifest fails loudly` | ✅ Covered |
+| AC | Manifest step missing a required field → fails naming the step | `walkthrough: Step missing a required field` | ✅ Covered |
+| AC | Manifest omits diagram entirely → fails loudly with a clear error | `walkthrough: Missing diagram fails loudly` | ✅ Covered |
+| AC | Horizontal mode provides a step counter, prev/next buttons, and keyboard arrow navigation | `walkthrough: Nav chrome available in horizontal mode` | ✅ Covered |
+| Design | Excerpt missing a required field (`path`/`startLine`/`code`) → fails naming both step and excerpt (design.md decision on validation, not a literal issue AC bullet but part of the same "loud, specific failure" contract) | `walkthrough: Excerpt missing a required field` | ✅ Covered |
+| Risk | Reopened "no interactivity beyond the toggle" scope line could keep expanding past what the owner actually approved | `walkthrough: Nav chrome available in horizontal mode` (requirement text bounds chrome to exactly counter + prev/next + keyboard — nothing more) | ✅ Covered |
+| Risk | Agent-authored inline SVG is harder to author correctly than a diagramming DSL, so early diagrams may be rough | — | ⚠️ Excluded — not mechanically testable; mitigated via `SKILL.md` guidance and the `diagram.type: "html"` lower-friction alternative, not a rendering behavior this spec can assert on |
+| Risk | `html_shell.py` extraction touches `generate-explain.py`, which has its own recent regression history | — | ⚠️ Excluded — this is a process safeguard (tasks.md 1.3/4.4: re-run `explain`'s own test suite, must stay 85/85), not a `walkthrough` capability requirement; covered by `explain`'s existing spec/tests, not a new scenario here |
+| Risk | `kind` accepting any string means a typo silently renders a slightly-wrong badge instead of failing | `walkthrough: Optional per-step kind badge` (requirement text explicitly states any string SHALL be accepted — this is the accepted, intended behavior per design.md decision 4, not a gap) | ✅ Covered |

--- a/openspec/changes/issue-42/design.md
+++ b/openspec/changes/issue-42/design.md
@@ -99,7 +99,12 @@ html_shell.py`, imported by both. *Owner decision* between this and "duplicate, 
 independent" (matching `explain`'s own "standalone, no other plugin required" philosophy applied
 one level down within `review-tools`) — the owner chose extraction, since the duplication really is
 byte-for-byte identical logic with zero schema coupling risk. `generate-explain.py`'s own test
-suite (currently 85/85) must stay green after this refactor — pure extraction, no behavior change.
+suite (currently 85/85) must stay green after this refactor. **Amendment, found during
+implementation:** the extraction itself (task 1) was pure/verbatim as planned, but a *later* commit
+building the walkthrough content model discovered and fixed a real escaping gap in the shared
+`inject_manifest()` (see the Risks section below) — a deliberate, reviewed departure from "no
+logic changes bundled," not an accident. `explain`'s test suite gained a dedicated regression case
+for it and stays green.
 
 **8. Markdown rendering for step narration reuses `explain`'s existing `renderMarkdown`/`inlineMD`
 JS logic, copied into the new `viewer.html`.** *Alternative considered:* writing a second,
@@ -121,9 +126,20 @@ shared-helpers case above; a `file://`-safe static HTML shell does not).
   data) as a lower-friction alternative to full SVG.
 - **[Risk] The `html_shell.py` extraction touches `generate-explain.py`, a file with its own recent
   history of subtle regressions (fence-masking, root-anchoring bugs fixed in 0.11.0/0.12.0)** **→
-  [Mitigation]** pure extraction only (move these three functions verbatim, change only the import
-  site) — no logic changes bundled into the same commit; `explain`'s full test suite re-run and
-  must stay 85/85 before this change is considered done.
+  [Mitigation, revised]** the *extraction* itself (task 1) was pure/verbatim — move the three
+  functions, change only the import site, no logic changes in that commit; `explain`'s full test
+  suite re-run and stayed 85/85. **What actually changed the mitigation:** building
+  walkthrough's own hostile-content fixture (a manifest excerpt containing `<!--` followed by
+  `<script`) surfaced a real, pre-existing gap in `inject_manifest()`'s escaping — `</`-only
+  escaping leaves HTML's script-data tokenizer able to enter double-escaped state, after which
+  the injected tag's own `</script>` no longer closes it and the page silently falls back to its
+  demo content. Fixed in the shared helper (escape every `<` as `<`, not just `</`), which
+  means `explain`'s injected output changed too — a deliberate, reviewed departure from "no logic
+  changes bundled into the same commit," not an oversight. The fix is strictly correct (verified:
+  round-trips through a real JS engine byte-identical to the authored content) and strictly safer
+  (closes a real hole, doesn't open one), so it was kept rather than reverted or deferred to a
+  separate change. `explain`'s test suite gained a dedicated regression case for exactly this
+  input shape (previously only walkthrough's own suite covered it) and both suites stay green.
 - **[Risk] `kind` accepting any string means a typo (`"tech-dept"`) silently renders a slightly
   wrong-looking badge instead of failing** **→ [Mitigation]** accepted trade-off (decision 4) —
   forward-compatibility was judged more valuable than typo-catching for a field with no fixed enum;

--- a/openspec/changes/issue-42/design.md
+++ b/openspec/changes/issue-42/design.md
@@ -1,0 +1,130 @@
+## Context
+
+`review-tools` already ships `explain`: a deterministic generator (`generate-explain.py`) that
+derives content from `git`/`gh` and injects it into a static, self-contained `viewer.html` shell
+via a `<!--MANIFEST-->` marker. `walkthrough` is a sibling with a fundamentally different job:
+`explain` reviews a *change*; `walkthrough` presents a *guided narrative* about an arbitrary
+topic/subsystem, with **no diff, issue, or git history to derive content from at all** — every
+byte of content (the diagram, the narration, the code excerpts chosen) is written by the invoking
+agent. This was worked out via an `architect` design consult during `/spec-flow:activate 42`, with
+the owner choosing among the options presented at each decision point below.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One self-contained HTML presentation per walkthrough: diagram first, then ordered steps, vertical
+  scroll by default, a runtime toggle to horizontal slide-by-slide navigation with nav chrome.
+- A manifest schema and validator specific to this content shape (not reused from `explain`'s
+  file-tree/diff schema, which has no meaningful mapping onto an ordered step sequence).
+- Reuse `explain`'s proven *pattern* (manifest JSON in, static HTML out, marker injection, loud
+  failure, `file://`-safe) without coupling the two tools' schemas or content models together.
+
+**Non-Goals:**
+- No code analysis, call-graph extraction, or any other mechanical derivation of diagram/step
+  content — `walkthrough` never shells out to `git`/`gh`/an AST tool. If content is wrong or
+  low-quality, that's the authoring agent's problem, not this tool's to detect.
+- No diagram rendering library (Mermaid or otherwise) — diagrams are agent-authored inline SVG/HTML
+  markup, embedded directly.
+- No interactivity beyond the vertical/horizontal toggle and its nav chrome (counter, prev/next,
+  keyboard arrows) — no in-browser editing, no comment channel, no server, no persistence.
+- No broader refactor of `generate-explain.py` — only the three specific helpers named below move
+  to the shared module; its remaining structure (issue #43) is out of scope here.
+
+## Decisions
+
+**1. The generator has no data-fetching responsibility — validate + render only.**
+Unlike `generate-explain.py`, `generate-walkthrough.py` takes `--manifest <path.json>` and does
+nothing but validate it and inject it into the viewer shell. *Alternative considered:* giving it an
+optional `--code <path>` convenience to pull excerpt text from disk instead of requiring the agent
+to inline it in the manifest — rejected for this change: it would blur "the manifest is the sole
+source of truth" and add a second way excerpt content can end up wrong (stale disk read vs. what
+the agent actually verified); can be reconsidered later if manifest authoring in practice turns out
+to be unwieldy.
+
+**2. Manifest schema is a fresh design, not modeled on `explain`'s tree-node schema.**
+```
+title: string
+subtitle?: string
+diagram: { type: "svg" | "html", source: string, caption?: string }   // required
+steps: [                                                                // required, >= 1
+  {
+    title: string
+    narration: string        // markdown
+    kind?: string             // any string accepted; renders a badge; omitted -> no badge
+    excerpts: [               // required, >= 1
+      { path: string, startLine: number, endLine?: number, code: string, lang?: string,
+        highlight?: number[] }
+    ]
+  }
+]
+```
+`explain`'s `path`-as-tree-nesting-key / `badge`+`badgeClass` / `kind: diff|code|markdown` schema
+has no meaningful analog here — this is a linear sequence, not a file tree. *Alternative
+considered:* forcing `walkthrough` steps into `explain`'s existing node shape so both tools share
+one schema — rejected: would couple two tools that fail, version, and get tested independently, for
+a structural fit that doesn't actually exist (there's no "path" to nest steps under).
+
+**3. Diagram rendering: agent-authored inline SVG/HTML, no rendering library.** *Owner decision,*
+architect presented three options (agent-authored-only / vendored Mermaid / support both) with
+trade-offs (dependency footprint, artifact size, agent authoring reliability vs. auto-layout). The
+owner chose agent-authored-only, on house-style grounds — matches `explain`'s "no framework, no
+external library" client-side convention and this environment's own diagramming convention
+elsewhere (inline SVG, no framework).
+
+**4. `kind` badge: forward-compatible, not a closed enum.** Any string value renders a badge
+(unrecognized values get a generic/neutral style); omission renders no badge. *Alternative
+considered:* hard-failing validation on an unrecognized `kind` (matching a closed
+`explanation|tech-debt|performance|recommendation` enum) — rejected: the acceptance criteria only
+require "present → badge, absent → no badge," and a closed enum would break the moment a fifth kind
+is wanted, for no testable benefit.
+
+**5. Nav chrome beyond the toggle: counter + prev/next + keyboard arrows.** *Owner decision* — the
+issue's original scope excluded "any interactivity beyond the toggle"; the architect flagged this
+as in direct tension with also being asked for nav-chrome options, and the owner resolved it by
+explicitly reopening that scope line (see the issue's own updated Scope section). Implemented as: a
+step counter, prev/next buttons, and left/right keyboard navigation, active in horizontal mode.
+
+**6. Horizontal toggle implementation: CSS `scroll-snap-type`, no JS animation.** A button toggles a
+`.horizontal` class on the steps container; CSS handles the layout switch via
+`scroll-snap-type: x mandatory` for horizontal slide-by-slide snapping. *Alternative considered:*
+a JS-driven animated transition between modes — rejected: no dependency, no hand-rolled animation
+code to maintain, and `explain`'s own viewer has no precedent for JS-driven layout animation either
+(its file-tree collapse/expand is a plain classList toggle, same idiom).
+
+**7. Code sharing with `explain`: pattern reuse only, plus one small shared module.** No shared
+schema, no shared viewer.html, no shared generator. The one exception: `fail()`, the
+`<!--MANIFEST-->` marker-injection helper, and the temp-output-path helper are genuinely identical
+between the two tools' current implementations — extracted into `plugins/review-tools/lib/
+html_shell.py`, imported by both. *Owner decision* between this and "duplicate, keep fully
+independent" (matching `explain`'s own "standalone, no other plugin required" philosophy applied
+one level down within `review-tools`) — the owner chose extraction, since the duplication really is
+byte-for-byte identical logic with zero schema coupling risk. `generate-explain.py`'s own test
+suite (currently 85/85) must stay green after this refactor — pure extraction, no behavior change.
+
+**8. Markdown rendering for step narration reuses `explain`'s existing `renderMarkdown`/`inlineMD`
+JS logic, copied into the new `viewer.html`.** *Alternative considered:* writing a second,
+independent markdown renderer — rejected as pointless duplication of already-working logic; not
+extracted into a shared JS file since these are two separate static HTML shells with no build step
+or module system to share client-side code through (Python has a real import system for the
+shared-helpers case above; a `file://`-safe static HTML shell does not).
+
+## Risks / Trade-offs
+
+- **[Risk] The reopened "no interactivity beyond the toggle" scope line could keep expanding** (a
+  counter suggests pagination, which suggests jump-to-step, which suggests...) **→ [Mitigation]**
+  the owner drew the line explicitly at counter + prev/next + keyboard arrows; anything beyond that
+  is a new idea, not an extension of this change.
+- **[Risk] Agent-authored inline SVG is harder to get right than a diagramming DSL like Mermaid, so
+  early walkthroughs may have rough/broken diagrams** **→ [Mitigation]** `SKILL.md` gives the
+  invoking agent concrete guidance and a worked example; `diagram.type: "html"` is also accepted (a
+  plain styled `<div>`-based diagram is often easier to hand-author correctly than raw SVG path
+  data) as a lower-friction alternative to full SVG.
+- **[Risk] The `html_shell.py` extraction touches `generate-explain.py`, a file with its own recent
+  history of subtle regressions (fence-masking, root-anchoring bugs fixed in 0.11.0/0.12.0)** **→
+  [Mitigation]** pure extraction only (move these three functions verbatim, change only the import
+  site) — no logic changes bundled into the same commit; `explain`'s full test suite re-run and
+  must stay 85/85 before this change is considered done.
+- **[Risk] `kind` accepting any string means a typo (`"tech-dept"`) silently renders a slightly
+  wrong-looking badge instead of failing** **→ [Mitigation]** accepted trade-off (decision 4) —
+  forward-compatibility was judged more valuable than typo-catching for a field with no fixed enum;
+  `SKILL.md` documents the conventional four values so an agent is likely to get it right anyway.

--- a/openspec/changes/issue-42/overrides.md
+++ b/openspec/changes/issue-42/overrides.md
@@ -1,0 +1,13 @@
+## Overrides existing behavior
+
+None — this change only adds new requirements (the new `walkthrough` capability). It contains no
+`MODIFIED Requirements` or `REMOVED Requirements` sections against any existing baseline spec.
+
+## Conflicts with other in-flight changes
+
+None found. The only other open change directory is `openspec-aware-explain-view`, which touches
+the `explain` capability exclusively — this change touches only the new `walkthrough` capability
+and has no delta-spec overlap with it. (This change's `html_shell.py` extraction does modify
+`generate-explain.py`'s implementation, but that's not a spec-level change — no requirement of the
+`explain` capability is added, modified, or removed by this change; see proposal.md's Capabilities
+section.)

--- a/openspec/changes/issue-42/proposal.md
+++ b/openspec/changes/issue-42/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+`explain`'s IDE-style file-tree/diff/pane view is well suited to reviewing a *change* (a diff, an
+issue, a PR), but it's the wrong shape for learning how something works end-to-end when there's no
+diff to open it against — a newcomer needs an ordered, one-idea-at-a-time narrative (see the shape
+first, then the code), not a self-navigated reference page. This isn't limited to "how does this
+work" either — the same shape (diagram first, then a guided code walkthrough) fits a technical-debt
+review, an areas-for-improvement pass, general recommendations, or a performance analysis just as
+well; only the content differs.
+
+## What Changes
+
+- Adds a new `walkthrough` skill to the `review-tools` plugin, alongside `explain`: an
+  agent-authored, diagram-first, ordered-step code presentation, rendered as one self-contained
+  static HTML file (no server, no CDN, opens via `file://`).
+- New deterministic renderer/generator (`generate-walkthrough.py`) that validates an agent-supplied
+  JSON manifest (diagram + ordered steps, each with narration, code excerpts, and an optional
+  `kind` tag) and renders it — it never fetches or derives content itself; all content is written
+  by the invoking agent, mirroring how `explain`'s `--explain-map` already works.
+- New static viewer shell (`assets/viewer.html`) with a genuinely different interaction model from
+  `explain`'s IDE-tree layout: diagram-first, ordered steps, vertical scroll by default with a
+  runtime toggle to horizontal slide-by-slide navigation (counter, prev/next, keyboard arrows) —
+  one generated artifact serves both modes, no regeneration needed to switch.
+- Extracts three helpers (`fail()`, the `<!--MANIFEST-->` injection helper, the temp-output-path
+  helper) that are genuinely identical between `generate-explain.py` and the new
+  `generate-walkthrough.py` into a small shared module, `plugins/review-tools/lib/html_shell.py`,
+  and refactors `generate-explain.py` to import from it instead of keeping its own copies —
+  **no behavior change** to `explain` (its own test suite must stay green throughout).
+- Bumps `plugins/review-tools/.claude-plugin/plugin.json`'s version and updates its
+  `description`/`keywords` to mention `walkthrough` alongside `explain`.
+
+## Capabilities
+
+### New Capabilities
+- `walkthrough`: an agent-authored, diagram-first, ordered-step code presentation tool — manifest
+  schema, validation rules, rendering (diagram + steps + code excerpts + kind badges), and the
+  vertical-default/horizontal-toggle presentation with nav chrome.
+
+### Modified Capabilities
+- None. The `html_shell.py` extraction changes `explain`'s internal implementation only — no
+  observable behavior, CLI surface, or requirement of the `explain` capability changes (verified by
+  its own test suite staying green), so no delta spec against `explain` is needed.
+
+## Impact
+
+- New files: `plugins/review-tools/skills/walkthrough/{SKILL.md,scripts/generate-walkthrough.py,
+  scripts/test-generate-walkthrough.sh,scripts/fixtures/*,scripts/README.md,assets/viewer.html}`,
+  `plugins/review-tools/lib/html_shell.py`.
+- Modified files: `plugins/review-tools/skills/explain/scripts/generate-explain.py` (import the
+  three extracted helpers instead of defining them locally), `plugins/review-tools/.claude-plugin/
+  plugin.json` (version bump + description/keywords).
+- No changes to `explain`'s manifest schema, CLI surface, or `assets/viewer.html`.
+- No new third-party dependencies (Python stdlib only; no Mermaid or other client-side rendering
+  library — diagrams are agent-authored inline SVG/HTML).

--- a/openspec/changes/issue-42/proposal.md
+++ b/openspec/changes/issue-42/proposal.md
@@ -24,8 +24,13 @@ well; only the content differs.
 - Extracts three helpers (`fail()`, the `<!--MANIFEST-->` injection helper, the temp-output-path
   helper) that are genuinely identical between `generate-explain.py` and the new
   `generate-walkthrough.py` into a small shared module, `plugins/review-tools/lib/html_shell.py`,
-  and refactors `generate-explain.py` to import from it instead of keeping its own copies —
-  **no behavior change** to `explain` (its own test suite must stay green throughout).
+  and refactors `generate-explain.py` to import from it instead of keeping its own copies.
+  **One deliberate exception to "no behavior change":** while building the shared
+  `inject_manifest()`, walkthrough's own hostile-content fixture surfaced a real gap in its
+  escaping (`</`-only escaping leaves an HTML script-data-tokenizer double-escape hole open —
+  see design.md decision 7) — fixed in the shared helper, so `explain`'s injected output changed
+  too (strictly safer, not a regression; both tools' full test suites, including a new regression
+  case added to `explain`'s own, stay green).
 - Bumps `plugins/review-tools/.claude-plugin/plugin.json`'s version and updates its
   `description`/`keywords` to mention `walkthrough` alongside `explain`.
 

--- a/openspec/changes/issue-42/specs/walkthrough/spec.md
+++ b/openspec/changes/issue-42/specs/walkthrough/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: Manifest-driven, diagram-first presentation rendering
+The system SHALL render a valid walkthrough manifest (a diagram plus an ordered, non-empty list of
+steps) as one self-contained HTML presentation file, with the diagram appearing before all step
+content and the steps rendered in the exact order given in the manifest.
+
+#### Scenario: Valid manifest renders in order
+- **WHEN** the generator is given a valid manifest containing a diagram and N ordered steps
+- **THEN** it produces one HTML file containing the diagram before all step content, with the N
+  steps appearing in the same order as the manifest
+
+### Requirement: Fully self-contained output
+The system SHALL produce output with no server dependency, no CDN reference, and no network call of
+any kind, so the rendered file opens correctly via `file://` alone.
+
+#### Scenario: No network references in rendered output
+- **WHEN** the rendered HTML file is inspected
+- **THEN** it contains no `http://`, `https://`, or `fetch(` reference anywhere in its content
+
+### Requirement: Vertical scroll by default, with a runtime horizontal toggle
+The system SHALL render the presentation with steps stacked in vertical-scroll layout by default,
+and SHALL include a control in the rendered page that switches the layout to horizontal
+slide-by-slide navigation and back, without requiring regeneration — a single generated artifact
+SHALL serve both viewing modes.
+
+#### Scenario: Default layout is vertical
+- **WHEN** the presentation is opened
+- **THEN** it defaults to vertical-scroll layout, with steps stacked top-to-bottom
+
+#### Scenario: Toggle switches to horizontal and back
+- **WHEN** the runtime toggle control is activated
+- **THEN** the layout switches to horizontal slide-by-slide navigation without any regeneration,
+  and activating it again returns to vertical layout — both modes are served by the same generated
+  file
+
+### Requirement: Horizontal-mode navigation chrome
+The system SHALL provide a step counter, previous/next buttons, and keyboard left/right arrow
+navigation for moving between steps while in horizontal mode.
+
+#### Scenario: Nav chrome available in horizontal mode
+- **WHEN** the presentation is in horizontal mode
+- **THEN** a step counter, previous/next buttons, and keyboard arrow navigation are all available
+  and functional for moving between steps
+
+### Requirement: Code excerpts render with their source reference
+The system SHALL render each step's one-or-more code excerpts together with their `file:line`
+source reference inside that step.
+
+#### Scenario: Excerpt and reference render together
+- **WHEN** a step includes one or more code excerpts with `file:line` references
+- **THEN** each excerpt's code and its source reference render inside that step
+
+### Requirement: Content-agnostic across walkthrough kinds
+The system SHALL use the same manifest schema and the same renderer regardless of what kind of
+walkthrough the content represents (an explanation of how something works, a technical-debt
+analysis, an areas-for-improvement review, general recommendations, or a performance analysis) —
+only the agent-authored content differs; there is no separate code path per kind.
+
+#### Scenario: Non-"how it works" walkthrough uses the same renderer
+- **WHEN** a manifest represents a technical-debt, improvement, recommendation, or performance
+  walkthrough rather than an explanation of how something works
+- **THEN** the same manifest schema and renderer produce the output — no separate code path is
+  invoked based on the kind of walkthrough
+
+### Requirement: Optional per-step kind badge
+The system SHALL render a small badge on a step when that step's manifest entry includes a `kind`
+field, and SHALL render no badge when `kind` is omitted. Any string value SHALL be accepted for
+`kind` — an unrecognized value SHALL still render (with a generic badge style), never causing
+validation to fail.
+
+#### Scenario: Kind present renders a badge
+- **WHEN** a step includes an optional `kind` field
+- **THEN** it renders as a small badge on that step
+
+#### Scenario: Kind omitted renders no badge
+- **WHEN** a step's `kind` field is omitted
+- **THEN** no badge shows for that step
+
+### Requirement: Loud failure on missing or empty manifest
+The system SHALL fail with a non-zero exit and a clear error message when invoked with no manifest,
+an unreadable manifest, or a manifest with no steps — never producing an empty presentation.
+
+#### Scenario: No manifest fails loudly
+- **WHEN** the generator is invoked with no manifest, an empty manifest, or a manifest with an
+  empty step list
+- **THEN** it fails with a non-zero exit and a clear error message, and produces no output file
+
+### Requirement: Loud, specific failure on an invalid step or excerpt
+The system SHALL fail generation, identifying the specific step (by its 1-based position and title,
+if present) and, where applicable, the specific excerpt within it, when a manifest step or excerpt
+is missing a required field.
+
+#### Scenario: Step missing a required field
+- **WHEN** a manifest step is missing a required field (`title`, `narration`, or a non-empty
+  `excerpts` list)
+- **THEN** generation fails with an error identifying which step is invalid
+
+#### Scenario: Excerpt missing a required field
+- **WHEN** an excerpt within a step is missing a required field (`path`, `startLine`, or `code`)
+- **THEN** generation fails with an error identifying both the step and the excerpt within it
+
+### Requirement: Diagram is mandatory
+The system SHALL fail generation with a clear error when a manifest omits the diagram entirely, or
+supplies a diagram with no `source` content.
+
+#### Scenario: Missing diagram fails loudly
+- **WHEN** the manifest omits the diagram entirely, or the diagram's `source` is empty
+- **THEN** generation fails with a clear error rather than producing a diagram-less presentation

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -229,3 +229,28 @@ this change's scope, found by the same pass):**
 - `explain`'s own markdown link renderer has the identical missing-scheme-allow-list gap as
   SEC-1 (7.2), fed genuinely untrusted GitHub content (already flagged there; repeated here for
   visibility since a second independent pass found it too).
+
+## 12. Fixes from a third correctness pass (nothing new caused by rounds 11's fixes themselves)
+
+- [x] 12.1 Fixed the exact falsy-zero class of bug the `startLine` fix (8.1) closed, but left
+      open for `endLine`: `validate_excerpt()` never validated `endLine` at all, so
+      `endLine: 0` (or any wrong-typed value) passed silently while the viewer's
+      `excerpt.endLine ? "-" + endLine : ""` treats it as absent -- the reference silently
+      renders as `path:100` instead of the intended range, with no error at generation time.
+      Now validated the same way as `startLine` (must be an int, and `>= startLine` when
+      present).
+- [x] 12.2 Corrected `SKILL.md`'s self-containment claim, which overstated actual enforcement
+      scope ("anywhere, including inside your diagram markup and narration") when the check is
+      deliberately `diagram.source`-only (7.5/8.2/11.2) -- narration/excerpt text mentioning a
+      URL is fine (inert text, not a live reference) and always has been; the doc now says so
+      accurately instead of promising an enforcement that does not exist and would be wrong to
+      add (it would contradict the deliberate diagram-only scope and break the already-tested
+      excerpt-code URL exemption, 9.2).
+      Both from a third, focused correctness pass -- confirmed nothing NEW was introduced by
+      round 11's own fixes; these are pre-existing gaps adjacent to what was fixed, not
+      regressions. Regression-tested (`excerpt-endline-zero.json`,
+      `excerpt-endline-before-start.json`); `test-generate-walkthrough.sh`: 142 -> 151 passing,
+      verified under real `/bin/bash` (3.2.57); `test-generate-explain.sh` unaffected at 88.
+
+Three passes of the built-in `/code-review` skill in a row now confirm no new issues introduced
+by the fixes themselves -- converging. Moving to Build (format/lint) and Polish.

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Extract shared helpers (do first — pure refactor, no behavior change)
 
-- [ ] 1.1 Create `plugins/review-tools/lib/html_shell.py` containing `fail()`, the
+- [x] 1.1 Create `plugins/review-tools/lib/html_shell.py` containing `fail()`, the
       `<!--MANIFEST-->` marker-injection helper (`inject_manifest()`), and the temp-output-path
       helper (`default_out_path()`), moved verbatim from `generate-explain.py`.
-- [ ] 1.2 Refactor `plugins/review-tools/skills/explain/scripts/generate-explain.py` to import
+- [x] 1.2 Refactor `plugins/review-tools/skills/explain/scripts/generate-explain.py` to import
       these three from `plugins/review-tools/lib/html_shell.py` instead of defining them locally —
       no other change to that file.
-- [ ] 1.3 Re-run `plugins/review-tools/skills/explain/scripts/test-generate-explain.sh` — must
+- [x] 1.3 Re-run `plugins/review-tools/skills/explain/scripts/test-generate-explain.sh` — must
       still be 85/85 passing. Fix immediately if not; this must land clean before any new code is
       built on top of it.
 

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -149,3 +149,21 @@
       implementation output changed, and strictly for the better.
 - [x] 7.8 Fixed a self-referential comment typo in `html_shell.py` ("every `<` then becomes a `<`
       escape" → "... becomes a `\u003c` escape").
+
+## 8. Fixes from the correctness (code-review) pass on round 1's own fixes
+
+- [x] 8.1 Fixed a real falsy-zero bug in `viewer.html`: `Number(excerpt.startLine) || 1` silently
+      replaced a legitimate `startLine: 0` with `1`, shifting every displayed gutter line number
+      by one and breaking any `highlight` entry written against 0-based input, with no error at
+      generation time. Fixed at the source instead: `validate_excerpt()` now rejects
+      `startLine < 1` (line numbers are 1-based; 0 is not "unset" -- the field's absence already
+      means that, and is already caught separately).
+- [x] 8.2 Fixed a real bug in round 1's own diagram self-containment check (7.5): it was a
+      case-sensitive substring match, so `HTTPS://` or `Http://` (URL schemes are case-insensitive
+      per RFC 3986; easy to produce via autocapitalization or copy-paste) bypassed it silently.
+      Now checks against a lowercased copy of `diagram.source`.
+      Both caught by an independent correctness pass via the built-in `/code-review` skill.
+      Regression-tested (`excerpt-startline-zero.json`, `diagram-mixed-case-url.json`); full
+      suite: `test-generate-walkthrough.sh` 108 -> 117, `test-generate-explain.sh` unaffected at
+      88 -- both verified under real `/bin/bash` (3.2.57).
+

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -196,3 +196,36 @@
       diagram" section: the markup must be agent-authored, never text copied from the code/docs/
       issues under review. No code change -- sanitizing would destroy the feature; the authoring
       rule is the only available control, so it needed to be written down.
+
+## 11. Fixes from a second correctness pass (confirming round 8-10's own fixes)
+
+- [x] 11.1 Fixed a real bypass in `isSafeLinkUrl` (7.2's XSS fix): a leading C0 control character
+      (e.g. "\x01javascript:alert(1)") or an embedded tab/newline (e.g. "java\tscript:...") let
+      a scheme check anchored on `^[a-zA-Z]` fall through to "no explicit scheme" -> accepted,
+      while a browser's URL parser strips exactly those characters (WHATWG URL spec) before
+      parsing the scheme and still executes it on click. Verified live with node before and
+      after the fix. `isSafeLinkUrl` now normalizes the same way a browser does before testing
+      the scheme.
+- [x] 11.2 Broadened the diagram self-containment check (7.5/8.2) beyond http(s) to also catch
+      `ftp://`, `ws://`, `wss://` -- other network schemes an agent could plausibly reference (an
+      image src, a websocket) that the prior check silently let through. (Bare protocol-relative
+      `//host/...` deliberately NOT added -- too common a substring in ordinary prose/markup for
+      a plain substring match to catch safely; spec.md's own scenario only names http(s)
+      explicitly.)
+      Both caught by a second, focused correctness pass via `/code-review` confirming round
+      8-10's own fixes -- this is genuinely a re-review, not the same pass repeated.
+      Regression-tested (`diagram-ftp-scheme.json`; the link-scheme fix is covered structurally,
+      since no headless browser is available in this suite -- correctness was verified live with
+      node during development). `test-generate-walkthrough.sh`: 135 -> 142 passing, verified
+      under real `/bin/bash` (3.2.57); `test-generate-explain.sh` unaffected at 88.
+
+**Flagged for the owner, deliberately NOT fixed here (pre-existing gaps in `explain`, outside
+this change's scope, found by the same pass):**
+- `generate-explain.py`'s own output-side writes (`viewer_path.read_text`,
+  `out_path.write_text`) are unguarded, unlike `generate-walkthrough.py`'s now-guarded
+  equivalent (7.4) -- a raw traceback instead of a clean `fail()` message.
+- `generate-explain.py`'s `--open` still discards `webbrowser.open()`'s return value with no
+  diagnostic -- the exact gap fixed in `generate-walkthrough.py` (7.4).
+- `explain`'s own markdown link renderer has the identical missing-scheme-allow-list gap as
+  SEC-1 (7.2), fed genuinely untrusted GitHub content (already flagged there; repeated here for
+  visibility since a second independent pass found it too).

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -167,3 +167,23 @@
       suite: `test-generate-walkthrough.sh` 108 -> 117, `test-generate-explain.sh` unaffected at
       88 -- both verified under real `/bin/bash` (3.2.57).
 
+
+## 9. Fixes from the test-rigor pass
+
+- [x] 9.1 Added three wrong-type-input fixtures/cases (`not-an-object.json`,
+      `title-wrong-type.json`, `steps-wrong-type.json`) -- every prior failure fixture tested a
+      field being ABSENT or EMPTY, never PRESENT-with-the-wrong-shape (a top-level JSON array
+      instead of an object, a non-string required field, a non-list `steps`) -- a real mistake an
+      agent authoring a manifest by hand could make, and a real antagonistic gap.
+- [x] 9.2 Added a positive-case fixture (`excerpt-code-with-url.json`) proving the diagram-only
+      self-containment scope is real: an excerpt's `code` containing an `https://` URL is
+      accepted and survives into the rendered output. Previously only the *rejection* side
+      (`diagram.source` containing a URL) was tested -- a regression broadening the check to the
+      whole manifest would have silently broken ordinary source code with a URL constant, with
+      nothing in the suite to catch it.
+- [x] 9.3 Added coverage for both `--open` outcomes (a documented part of the CLI contract) via
+      direct `webbrowser.open` monkeypatching, not the `$BROWSER` env var -- confirmed live that
+      `$BROWSER` is not a reliable cross-platform mock (macOS routes `webbrowser.open()` through
+      its own AppleScript-based controller regardless of `$BROWSER`).
+      `test-generate-walkthrough.sh`: 117 -> 135 passing, verified under real `/bin/bash`
+      (3.2.57); `test-generate-explain.sh` unaffected at 88.

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -85,12 +85,12 @@
 
 ## 5. Documentation
 
-- [ ] 5.1 Write `plugins/review-tools/skills/walkthrough/SKILL.md`: manifest schema (mirroring how
+- [x] 5.1 Write `plugins/review-tools/skills/walkthrough/SKILL.md`: manifest schema (mirroring how
       `explain`'s `SKILL.md` documents its own schema), CLI usage, and — the actual "how to use
       me" contract — guidance for the invoking agent on what to investigate before authoring a
       manifest and how to write a good diagram/narration for each of the five walkthrough kinds
       (explanation, tech-debt, improvements, recommendations, performance).
-- [ ] 5.2 Write `plugins/review-tools/skills/walkthrough/scripts/README.md` documenting the test
+- [x] 5.2 Write `plugins/review-tools/skills/walkthrough/scripts/README.md` documenting the test
       suite, mirroring `explain`'s sibling `scripts/README.md`.
 
 ## 6. Versioning
@@ -99,5 +99,5 @@
       `plugins/review-tools/.claude-plugin/plugin.json` before changing it (this repo's
       established convention — propose a minor bump per the repo's stated default, from whatever
       the current version is at implementation time).
-- [ ] 6.2 Update `plugin.json`'s `description`/`keywords` to mention `walkthrough` alongside
+- [x] 6.2 Update `plugin.json`'s `description`/`keywords` to mention `walkthrough` alongside
       `explain`.

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -12,57 +12,57 @@
 
 ## 2. Manifest schema and validation
 
-- [ ] 2.1 Create `plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py` with the
+- [x] 2.1 Create `plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py` with the
       manifest schema from design.md decision 2 (`title`, `subtitle?`, `diagram: {type, source,
       caption?}`, `steps: [{title, narration, kind?, excerpts: [{path, startLine, endLine?, code,
       lang?, highlight?}]}]`).
-- [ ] 2.2 Implement validation, using `fail()` from `html_shell.py`, matching spec.md's
+- [x] 2.2 Implement validation, using `fail()` from `html_shell.py`, matching spec.md's
       requirements exactly:
       - missing/unreadable/empty manifest, or empty `steps` → fail, no output file
       - missing/empty `diagram`, or empty `diagram.source` → fail
       - a step missing `title`/`narration`/non-empty `excerpts` → fail naming the step (1-based
         index + title if present)
       - an excerpt missing `path`/`startLine`/`code` → fail naming both the step and the excerpt
-- [ ] 2.3 CLI surface: `generate-walkthrough.py --manifest <path.json> [--out <path>] [--open]` —
+- [x] 2.3 CLI surface: `generate-walkthrough.py --manifest <path.json> [--out <path>] [--open]` —
       no `--title`/`--subtitle` flags. Same "print path + `open <path>` line, `--open` only for
       foreground use" contract as `explain`, via the shared helpers from section 1.
 
 ## 3. Viewer shell (assets/viewer.html)
 
-- [ ] 3.1 Create `plugins/review-tools/skills/walkthrough/assets/viewer.html` — self-contained,
+- [x] 3.1 Create `plugins/review-tools/skills/walkthrough/assets/viewer.html` — self-contained,
       vanilla JS, no framework, no build step, `<!--MANIFEST-->` marker for injection, a
       `DEMO_MANIFEST` fallback for opening the shell directly (matching `explain`'s own
       convention).
-- [ ] 3.2 Diagram renders first (before any step content): embed `diagram.source` (SVG or HTML)
+- [x] 3.2 Diagram renders first (before any step content): embed `diagram.source` (SVG or HTML)
       directly, plus `diagram.caption` if given.
-- [ ] 3.3 Steps render in manifest order: title, narration (markdown — copy `explain`'s
+- [x] 3.3 Steps render in manifest order: title, narration (markdown — copy `explain`'s
       `renderMarkdown`/`inlineMD` logic into this file per design.md decision 8, don't write a
       second renderer), one-or-more code excerpts (each showing `path:startLine`-`endLine`, a
       `data-lang` attribute from `lang` if given, `highlight` lines visually distinguished via
       CSS), and a `kind` badge if present (any string value → a badge; unrecognized values get a
       generic/neutral style; omitted → no badge).
-- [ ] 3.4 Vertical-scroll default layout (steps stacked top-to-bottom).
-- [ ] 3.5 Runtime toggle control: flips a `.horizontal` class on the steps container; CSS switches
+- [x] 3.4 Vertical-scroll default layout (steps stacked top-to-bottom).
+- [x] 3.5 Runtime toggle control: flips a `.horizontal` class on the steps container; CSS switches
       to horizontal layout via `scroll-snap-type: x mandatory` — no JS-driven animation.
       Re-toggling returns to vertical. One artifact, no regeneration needed either direction.
-- [ ] 3.6 Horizontal-mode nav chrome: step counter ("Step N of M"), prev/next buttons, and
+- [x] 3.6 Horizontal-mode nav chrome: step counter ("Step N of M"), prev/next buttons, and
       keyboard left/right arrow navigation — all functional for moving between steps.
-- [ ] 3.7 Confirm no `http://`, `https://`, or `fetch(` anywhere in the shell — self-contained,
+- [x] 3.7 Confirm no `http://`, `https://`, or `fetch(` anywhere in the shell — self-contained,
       `file://`-safe.
 
 ## 4. Fixtures and test suite
 
-- [ ] 4.1 Create `plugins/review-tools/skills/walkthrough/scripts/fixtures/` with small JSON
+- [x] 4.1 Create `plugins/review-tools/skills/walkthrough/scripts/fixtures/` with small JSON
       manifests: a valid multi-step manifest (diagram + 2+ steps, at least one with a `kind`, at
       least one step with multiple excerpts), and one fixture per failure mode (missing manifest
       path handled by test invocation itself; empty manifest; missing diagram; empty diagram
       source; step missing title; step missing narration; step with empty excerpts; excerpt
       missing path; excerpt missing startLine; excerpt missing code).
-- [ ] 4.2 Create `plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh`,
+- [x] 4.2 Create `plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh`,
       bash 3.2 compatible (no associative arrays, no `mapfile`), following
       `test-generate-explain.sh`'s conventions: a `check()` helper tallying PASS/FAIL,
       JSON-shaped assertions delegated to `python3 -` for parsing rendered HTML.
-- [ ] 4.3 Test coverage, one case per spec.md requirement/scenario:
+- [x] 4.3 Test coverage, one case per spec.md requirement/scenario:
       - valid manifest renders: diagram before all step content, steps in given order
       - self-containment: no `http(s)://`/`fetch(` in rendered output
       - defaults to vertical layout (structural check for the absence of the `.horizontal` class
@@ -80,7 +80,7 @@
       - step missing a required field → non-zero exit, error names the step
       - excerpt missing a required field → non-zero exit, error names step + excerpt
       - missing diagram / empty diagram source → non-zero exit, clear error
-- [ ] 4.4 Full run: all new tests passing, plus `test-generate-explain.sh` still 85/85 (re-verify
+- [x] 4.4 Full run: all new tests passing, plus `test-generate-explain.sh` still 85/85 (re-verify
       after section 1's refactor is in place alongside the new code).
 
 ## 5. Documentation

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -254,3 +254,16 @@ this change's scope, found by the same pass):**
 
 Three passes of the built-in `/code-review` skill in a row now confirm no new issues introduced
 by the fixes themselves -- converging. Moving to Build (format/lint) and Polish.
+
+## 13. Build and Polish
+
+- [x] 13.1 Build: no format/lint/build tooling is configured in this repo (no pyproject.toml,
+      no eslint config, no CI step referencing one) -- confirmed `python3 -m py_compile` and
+      `bash -n` clean on every touched file. Ran `shellcheck`/`ruff` informally (not a repo
+      requirement) as a bonus sanity check: the new files (`generate-walkthrough.py`,
+      `html_shell.py`) are fully clean; the handful of shellcheck notes on the new test script
+      match the same class already present, unfixed, in the sibling `test-generate-explain.sh`
+      (an established convention, not a new gap).
+- [x] 13.2 Polish: updated the top-level `README.md`'s `review-tools` section to describe both
+      skills (previously `explain`-only) and added a `/walkthrough` row to its skills table,
+      linking both `SKILL.md` files.

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -187,3 +187,12 @@
       its own AppleScript-based controller regardless of `$BROWSER`).
       `test-generate-walkthrough.sh`: 117 -> 135 passing, verified under real `/bin/bash`
       (3.2.57); `test-generate-explain.sh` unaffected at 88.
+
+## 10. Remaining low-severity security finding
+
+- [x] 10.1 SEC-2 (low): `diagram.source` is an intentional, unsanitized `innerHTML` sink -- the
+      one place content executes with no click, unlike the SEC-1 link case -- but its trust
+      constraint was undocumented. Added an explicit bullet to `SKILL.md`'s "Authoring the
+      diagram" section: the markup must be agent-authored, never text copied from the code/docs/
+      issues under review. No code change -- sanitizing would destroy the feature; the authoring
+      rule is the only available control, so it needed to be written down.

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -1,0 +1,103 @@
+## 1. Extract shared helpers (do first — pure refactor, no behavior change)
+
+- [ ] 1.1 Create `plugins/review-tools/lib/html_shell.py` containing `fail()`, the
+      `<!--MANIFEST-->` marker-injection helper (`inject_manifest()`), and the temp-output-path
+      helper (`default_out_path()`), moved verbatim from `generate-explain.py`.
+- [ ] 1.2 Refactor `plugins/review-tools/skills/explain/scripts/generate-explain.py` to import
+      these three from `plugins/review-tools/lib/html_shell.py` instead of defining them locally —
+      no other change to that file.
+- [ ] 1.3 Re-run `plugins/review-tools/skills/explain/scripts/test-generate-explain.sh` — must
+      still be 85/85 passing. Fix immediately if not; this must land clean before any new code is
+      built on top of it.
+
+## 2. Manifest schema and validation
+
+- [ ] 2.1 Create `plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py` with the
+      manifest schema from design.md decision 2 (`title`, `subtitle?`, `diagram: {type, source,
+      caption?}`, `steps: [{title, narration, kind?, excerpts: [{path, startLine, endLine?, code,
+      lang?, highlight?}]}]`).
+- [ ] 2.2 Implement validation, using `fail()` from `html_shell.py`, matching spec.md's
+      requirements exactly:
+      - missing/unreadable/empty manifest, or empty `steps` → fail, no output file
+      - missing/empty `diagram`, or empty `diagram.source` → fail
+      - a step missing `title`/`narration`/non-empty `excerpts` → fail naming the step (1-based
+        index + title if present)
+      - an excerpt missing `path`/`startLine`/`code` → fail naming both the step and the excerpt
+- [ ] 2.3 CLI surface: `generate-walkthrough.py --manifest <path.json> [--out <path>] [--open]` —
+      no `--title`/`--subtitle` flags. Same "print path + `open <path>` line, `--open` only for
+      foreground use" contract as `explain`, via the shared helpers from section 1.
+
+## 3. Viewer shell (assets/viewer.html)
+
+- [ ] 3.1 Create `plugins/review-tools/skills/walkthrough/assets/viewer.html` — self-contained,
+      vanilla JS, no framework, no build step, `<!--MANIFEST-->` marker for injection, a
+      `DEMO_MANIFEST` fallback for opening the shell directly (matching `explain`'s own
+      convention).
+- [ ] 3.2 Diagram renders first (before any step content): embed `diagram.source` (SVG or HTML)
+      directly, plus `diagram.caption` if given.
+- [ ] 3.3 Steps render in manifest order: title, narration (markdown — copy `explain`'s
+      `renderMarkdown`/`inlineMD` logic into this file per design.md decision 8, don't write a
+      second renderer), one-or-more code excerpts (each showing `path:startLine`-`endLine`, a
+      `data-lang` attribute from `lang` if given, `highlight` lines visually distinguished via
+      CSS), and a `kind` badge if present (any string value → a badge; unrecognized values get a
+      generic/neutral style; omitted → no badge).
+- [ ] 3.4 Vertical-scroll default layout (steps stacked top-to-bottom).
+- [ ] 3.5 Runtime toggle control: flips a `.horizontal` class on the steps container; CSS switches
+      to horizontal layout via `scroll-snap-type: x mandatory` — no JS-driven animation.
+      Re-toggling returns to vertical. One artifact, no regeneration needed either direction.
+- [ ] 3.6 Horizontal-mode nav chrome: step counter ("Step N of M"), prev/next buttons, and
+      keyboard left/right arrow navigation — all functional for moving between steps.
+- [ ] 3.7 Confirm no `http://`, `https://`, or `fetch(` anywhere in the shell — self-contained,
+      `file://`-safe.
+
+## 4. Fixtures and test suite
+
+- [ ] 4.1 Create `plugins/review-tools/skills/walkthrough/scripts/fixtures/` with small JSON
+      manifests: a valid multi-step manifest (diagram + 2+ steps, at least one with a `kind`, at
+      least one step with multiple excerpts), and one fixture per failure mode (missing manifest
+      path handled by test invocation itself; empty manifest; missing diagram; empty diagram
+      source; step missing title; step missing narration; step with empty excerpts; excerpt
+      missing path; excerpt missing startLine; excerpt missing code).
+- [ ] 4.2 Create `plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh`,
+      bash 3.2 compatible (no associative arrays, no `mapfile`), following
+      `test-generate-explain.sh`'s conventions: a `check()` helper tallying PASS/FAIL,
+      JSON-shaped assertions delegated to `python3 -` for parsing rendered HTML.
+- [ ] 4.3 Test coverage, one case per spec.md requirement/scenario:
+      - valid manifest renders: diagram before all step content, steps in given order
+      - self-containment: no `http(s)://`/`fetch(` in rendered output
+      - defaults to vertical layout (structural check for the absence of the `.horizontal` class
+        on initial render, and presence of the toggle control)
+      - toggle control and horizontal-mode CSS/JS are structurally present (grep-based check on
+        the rendered HTML, same "no headless browser" convention `test-generate-explain.sh`
+        already uses for `viewer.html`'s own JS)
+      - nav chrome elements (counter, prev/next, keyboard handler) structurally present
+      - code excerpt + file:line reference render inside their step
+      - non-"how it works" `kind` values (`tech-debt`/`performance`/`recommendation`) render
+        through the same code path as `explanation` — same assertion logic, different fixture
+      - `kind` present → badge present; `kind` omitted → no badge; unrecognized `kind` string
+        still renders (doesn't fail)
+      - no manifest / empty manifest / empty steps → non-zero exit, no output file
+      - step missing a required field → non-zero exit, error names the step
+      - excerpt missing a required field → non-zero exit, error names step + excerpt
+      - missing diagram / empty diagram source → non-zero exit, clear error
+- [ ] 4.4 Full run: all new tests passing, plus `test-generate-explain.sh` still 85/85 (re-verify
+      after section 1's refactor is in place alongside the new code).
+
+## 5. Documentation
+
+- [ ] 5.1 Write `plugins/review-tools/skills/walkthrough/SKILL.md`: manifest schema (mirroring how
+      `explain`'s `SKILL.md` documents its own schema), CLI usage, and — the actual "how to use
+      me" contract — guidance for the invoking agent on what to investigate before authoring a
+      manifest and how to write a good diagram/narration for each of the five walkthrough kinds
+      (explanation, tech-debt, improvements, recommendations, performance).
+- [ ] 5.2 Write `plugins/review-tools/skills/walkthrough/scripts/README.md` documenting the test
+      suite, mirroring `explain`'s sibling `scripts/README.md`.
+
+## 6. Versioning
+
+- [ ] 6.1 Ask the owner to confirm the exact new version number for
+      `plugins/review-tools/.claude-plugin/plugin.json` before changing it (this repo's
+      established convention — propose a minor bump per the repo's stated default, from whatever
+      the current version is at implementation time).
+- [ ] 6.2 Update `plugin.json`'s `description`/`keywords` to mention `walkthrough` alongside
+      `explain`.

--- a/openspec/changes/issue-42/tasks.md
+++ b/openspec/changes/issue-42/tasks.md
@@ -1,4 +1,5 @@
-## 1. Extract shared helpers (do first — pure refactor, no behavior change)
+## 1. Extract shared helpers (do first — pure refactor at this step; see task 7 for a later,
+      deliberate departure discovered while building on top of it)
 
 - [x] 1.1 Create `plugins/review-tools/lib/html_shell.py` containing `fail()`, the
       `<!--MANIFEST-->` marker-injection helper (`inject_manifest()`), and the temp-output-path
@@ -101,3 +102,50 @@
       the current version is at implementation time).
 - [x] 6.2 Update `plugin.json`'s `description`/`keywords` to mention `walkthrough` alongside
       `explain`.
+
+## 7. Fixes from the implement review panel
+
+- [x] 7.1 Fixed a real bash 3.2 syntax error in `test-generate-walkthrough.sh` (an apostrophe
+      inside a Python comment nested in a heredoc within `$(...)` tripped a known bash 3.2
+      command-substitution parser quirk) — the suite silently died mid-run under macOS system
+      bash with no pass/fail tally at all, dropping ~60 of 108 assertions (every failure-mode
+      case, the vertical-default check, all viewer-shell structural checks). Only appeared to
+      pass because Homebrew bash was earlier in `$PATH` during earlier verification. Fixed by
+      removing every apostrophe from the affected block, not just the one that first triggered
+      it; verified 108/108 under real `/bin/bash` (bash 3.2.57) afterward.
+- [x] 7.2 Fixed a real medium-severity XSS: `viewer.html`'s markdown link renderer accepted
+      `javascript:`/`data:` URI schemes in step narration with no allow-list, so a link became
+      click-to-execute script. Added `isSafeLinkUrl()` (http(s)/mailto or no explicit scheme only)
+      and route link rendering through it — an unsafe URL renders as inert text instead of an
+      anchor. `explain`'s own viewer has the identical pre-existing gap, fed genuinely untrusted
+      GitHub content — flagged for the owner to triage separately, not fixed here (out of scope
+      for this change).
+- [x] 7.3 Fixed a real observability gap: if the injected manifest ever fails to parse for any
+      reason (a future escaping regression, a truncated file), the viewer silently rendered
+      `DEMO_MANIFEST` with zero diagnostic — a reviewer could mistake demo content for the real
+      thing. `boot()` now logs to the console and shows a visible banner whenever
+      `window.MANIFEST` is falsy, whatever the reason.
+- [x] 7.4 `generate-walkthrough.py`: guarded the two output-side filesystem operations (reading
+      `viewer.html`, writing the output file) with the same `try`/`except OSError` → `fail()`
+      pattern already used on the read-manifest path, instead of letting them surface as a raw
+      traceback. Also: `--open`'s `webbrowser.open()` return value is now checked, with a stderr
+      warning on failure (e.g. a headless host) — previously silent.
+- [x] 7.5 `generate-walkthrough.py`: `validate_diagram()` now rejects `http://`/`https://` in
+      `diagram.source` — the one network-reference check the tool can cheaply make itself for
+      spec.md's self-contained-output requirement, catching the most common real-world trigger
+      (an SVG author's default `xmlns` attribute, which `SKILL.md` already tells agents to omit
+      but nothing previously enforced).
+- [x] 7.6 Added a dedicated regression case to `explain`'s own `test-generate-explain.sh` for the
+      `inject_manifest()` escaping fix (7.7) — a `--doc` file quoting the same hostile
+      `<!--`+`<script` shape walkthrough's fixture uses. Verified non-vacuous by temporarily
+      reverting the escaping fix and confirming this exact case fails; 88/88 passing with the fix
+      restored, under real bash 3.2.
+- [x] 7.7 Corrected `proposal.md`, `design.md` (decision 7 and its matching Risks entry) to
+      honestly describe the `inject_manifest()` escaping change bundled into the shared-lib work,
+      instead of the original "pure extraction, no behavior change" claim — see design.md's Risks
+      section for the full account of what was found and why it was kept rather than reverted.
+      `overrides.md` needed no change: no requirement of the `explain` capability was added,
+      modified, or removed (confirmed against `openspec/specs/explain/spec.md`) — only its
+      implementation output changed, and strictly for the better.
+- [x] 7.8 Fixed a self-referential comment typo in `html_shell.py` ("every `<` then becomes a `<`
+      escape" → "... becomes a `\u003c` escape").

--- a/plugins/review-tools/.claude-plugin/plugin.json
+++ b/plugins/review-tools/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "review-tools",
   "version": "0.12.0",
-  "description": "Render an IDE-style single-page HTML view of a code diff, a GitHub issue plus everything linked to it, or docs — self-contained, no server. Standalone; also wired into spec-flow's owner seams when both plugins are installed.",
+  "description": "Render a change or a subsystem as one self-contained HTML page, no server: `explain` gives an IDE-style view of a code diff, a GitHub issue plus everything linked to it, or docs; `walkthrough` gives a diagram-first, ordered-step presentation — how something works, a tech-debt or performance analysis, recommendations. Standalone; also wired into spec-flow's owner seams when both plugins are installed.",
   "author": { "name": "Jon Haddad" },
   "repository": "https://github.com/rustyrazorblade/skills",
   "license": "Apache-2.0",
-  "keywords": ["review", "diff", "github", "issues", "html", "visualization"]
+  "keywords": ["review", "diff", "github", "issues", "html", "visualization", "walkthrough", "presentation", "diagram"]
 }

--- a/plugins/review-tools/lib/html_shell.py
+++ b/plugins/review-tools/lib/html_shell.py
@@ -20,7 +20,7 @@ def fail(message, prog):
 
 
 def inject_manifest(viewer_html, manifest, prog):
-    # ensure_ascii keeps the payload plain-ASCII-safe; every "<" then becomes a "<" escape,
+    # ensure_ascii keeps the payload plain-ASCII-safe; every "<" then becomes a "\u003c" escape,
     # which is safe because inside JSON a "<" can only ever appear within a string literal, and
     # the parser resolves the escape back to the same character. Escaping only "</" is not
     # enough: HTML's script-data tokenizer treats an embedded "<!--" followed by "<script" as

--- a/plugins/review-tools/lib/html_shell.py
+++ b/plugins/review-tools/lib/html_shell.py
@@ -1,0 +1,40 @@
+"""Helpers shared by review-tools' HTML generators (`generate-explain.py`,
+`generate-walkthrough.py`): loud failure, manifest injection into a static viewer shell, and the
+default temp output path. Stdlib only — same constraint as the generators themselves (macOS system
+python3 and CI Linux, no pip dependencies).
+
+Each generator passes its own program name / filename prefix, since those are the only parts of
+this logic that ever differed between them.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+def fail(message, prog):
+    print(f"{prog}: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def inject_manifest(viewer_html, manifest, prog):
+    # ensure_ascii keeps the payload plain-ASCII-safe; escaping "</" as "<\/" is the standard
+    # technique to stop an embedded "</script>" substring (e.g. inside a doc or diff) from
+    # prematurely closing the injected <script> tag.
+    manifest_json = json.dumps(manifest, ensure_ascii=True).replace("</", "<\\/")
+    script_tag = f"<script>window.MANIFEST = {manifest_json};</script>"
+    if "<!--MANIFEST-->" not in viewer_html:
+        fail("assets/viewer.html is missing its <!--MANIFEST--> marker — was it edited?", prog)
+    return viewer_html.replace("<!--MANIFEST-->", script_tag, 1)
+
+
+def default_out_path(prefix):
+    fd_path = Path(tempfile.gettempdir())
+    fd_path.mkdir(parents=True, exist_ok=True)
+    # mkstemp for a guaranteed-unique name; the caller immediately overwrites it, so the empty
+    # file it creates is just a placeholder reservation.
+    fd, name = tempfile.mkstemp(prefix=prefix, suffix=".html", dir=str(fd_path))
+    os.close(fd)
+    return Path(name)

--- a/plugins/review-tools/lib/html_shell.py
+++ b/plugins/review-tools/lib/html_shell.py
@@ -20,10 +20,14 @@ def fail(message, prog):
 
 
 def inject_manifest(viewer_html, manifest, prog):
-    # ensure_ascii keeps the payload plain-ASCII-safe; escaping "</" as "<\/" is the standard
-    # technique to stop an embedded "</script>" substring (e.g. inside a doc or diff) from
-    # prematurely closing the injected <script> tag.
-    manifest_json = json.dumps(manifest, ensure_ascii=True).replace("</", "<\\/")
+    # ensure_ascii keeps the payload plain-ASCII-safe; every "<" then becomes a "<" escape,
+    # which is safe because inside JSON a "<" can only ever appear within a string literal, and
+    # the parser resolves the escape back to the same character. Escaping only "</" is not
+    # enough: HTML's script-data tokenizer treats an embedded "<!--" followed by "<script" as
+    # entering double-escaped state, after which a later "</script>" no longer closes the tag —
+    # content as ordinary as an HTML template excerpt ("<!--[if IE]><script>") would then eat
+    # the rest of the page and silently render the shell's demo fallback instead.
+    manifest_json = json.dumps(manifest, ensure_ascii=True).replace("<", "\\u003c")
     script_tag = f"<script>window.MANIFEST = {manifest_json};</script>"
     if "<!--MANIFEST-->" not in viewer_html:
         fail("assets/viewer.html is missing its <!--MANIFEST--> marker — was it edited?", prog)

--- a/plugins/review-tools/skills/explain/scripts/README.md
+++ b/plugins/review-tools/skills/explain/scripts/README.md
@@ -7,6 +7,10 @@
   compatible.
 - `test-generate-explain.sh` — structural self-test for the two scripts above.
 
+`generate-explain.py` imports `fail()`, the `<!--MANIFEST-->` injection helper, and the
+temp-output-path helper from `plugins/review-tools/lib/html_shell.py`, which it shares with the
+sibling `walkthrough` skill's generator — a change there affects both.
+
 ## Running the test
 
 ```bash

--- a/plugins/review-tools/skills/explain/scripts/generate-explain.py
+++ b/plugins/review-tools/skills/explain/scripts/generate-explain.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Deterministic generator for an `explain` walkthrough: a single self-contained HTML file built
 from a git diff, a GitHub issue + its related issues, and/or optional docs/code, with zero
-model-authored markup. Stdlib only (json, argparse, subprocess, pathlib, tempfile, webbrowser) +
+model-authored markup. Stdlib only (json, argparse, subprocess, pathlib, webbrowser) +
 shelling out to `git`/`gh` — no pip dependencies. Must run on macOS system python3 and in CI
 (Linux); avoid anything requiring a compiled extension.
 
@@ -10,14 +10,21 @@ See plugins/review-tools/skills/explain/SKILL.md for the manifest schema and usa
 
 import argparse
 import fnmatch
+import functools
 import json
 import re
 import shutil
 import subprocess
 import sys
-import tempfile
 import webbrowser
 from pathlib import Path, PurePosixPath
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "lib"))
+from html_shell import default_out_path, inject_manifest  # noqa: E402
+from html_shell import fail as _fail  # noqa: E402
+
+PROG = "generate-explain"
+fail = functools.partial(_fail, prog=PROG)
 
 # The canonical "nothing here yet" tree — diffing against it renders a from-scratch add of
 # everything in <head>. Used only when no other base can be resolved (e.g. a repo with a single
@@ -33,11 +40,6 @@ LANG_BY_SUFFIX = {
     ".c": "c", ".h": "c", ".cpp": "cpp", ".hpp": "cpp", ".swift": "swift", ".html": "html",
     ".css": "css",
 }
-
-
-def fail(message):
-    print(f"generate-explain: {message}", file=sys.stderr)
-    sys.exit(1)
 
 
 def run_git(args, cwd=None):
@@ -881,28 +883,6 @@ def build_manifest(args, base, head):
     return manifest
 
 
-def inject_manifest(viewer_html, manifest):
-    # ensure_ascii keeps the payload plain-ASCII-safe; escaping "</" as "<\/" is the standard
-    # technique to stop an embedded "</script>" substring (e.g. inside a doc or diff) from
-    # prematurely closing the injected <script> tag.
-    manifest_json = json.dumps(manifest, ensure_ascii=True).replace("</", "<\\/")
-    script_tag = f"<script>window.MANIFEST = {manifest_json};</script>"
-    if "<!--MANIFEST-->" not in viewer_html:
-        fail("assets/viewer.html is missing its <!--MANIFEST--> marker — was it edited?")
-    return viewer_html.replace("<!--MANIFEST-->", script_tag, 1)
-
-
-def default_out_path():
-    fd_path = Path(tempfile.gettempdir())
-    fd_path.mkdir(parents=True, exist_ok=True)
-    # mkstemp for a guaranteed-unique name; we immediately overwrite via write_text below, so the
-    # empty file it creates is just a placeholder reservation.
-    import os
-    fd, name = tempfile.mkstemp(prefix="explain-", suffix=".html", dir=str(fd_path))
-    os.close(fd)
-    return Path(name)
-
-
 def main():
     parser = argparse.ArgumentParser(description="Generate a deterministic IDE-style HTML explain view from a git diff, a GitHub issue, and/or docs.")
     parser.add_argument("--diff", action="store_true",
@@ -971,9 +951,9 @@ def main():
         fail(f"viewer shell not found at {viewer_path} — was assets/viewer.html removed?")
     viewer_html = viewer_path.read_text(encoding="utf-8")
 
-    out_html = inject_manifest(viewer_html, manifest)
+    out_html = inject_manifest(viewer_html, manifest, PROG)
 
-    out_path = Path(args.out).resolve() if args.out else default_out_path()
+    out_path = Path(args.out).resolve() if args.out else default_out_path("explain-")
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(out_html, encoding="utf-8")
 

--- a/plugins/review-tools/skills/explain/scripts/test-generate-explain.sh
+++ b/plugins/review-tools/skills/explain/scripts/test-generate-explain.sh
@@ -1184,6 +1184,59 @@ echo "$title_py_out"
 pass_count=$((pass_count + $(echo "$title_py_out" | grep -c '^PASS:')))
 fail_count=$((fail_count + $(echo "$title_py_out" | grep -c '^FAIL:')))
 
+# ---------------------------------------------------------------------------
+# inject_manifest() shares html_shell.py with the walkthrough skill (issue-42)
+# -- content containing "<!--" followed by "<script" would, under the old
+# "</" -only escaping, put HTML's script-data tokenizer into double-escaped
+# state and break the injected <script> tag open. explain is the consumer
+# that actually ingests hostile third-party content (docs, diffs, issue
+# bodies), so this needs its own regression coverage, not just walkthrough's.
+# ---------------------------------------------------------------------------
+hostile_doc="$out_dir/hostile-template.md"
+cat > "$hostile_doc" <<'EOF'
+# A doc quoting an HTML template
+
+```html
+<!--[if IE]><script src="shim.js"></script><![endif]-->
+<div id="app"></div>
+```
+EOF
+
+hostile_doc_html="$out_dir/explain-hostile-doc-test.html"
+(
+  cd "$repo" && python3 "$generate_explain" --doc "$hostile_doc" --out "$hostile_doc_html"
+)
+check "generate-explain.py --doc exits 0 for a doc quoting an HTML template with a script tag" $?
+
+hostile_py_out="$(python3 - "$hostile_doc_html" <<'PYEOF'
+import json
+import sys
+
+content = open(sys.argv[1], encoding="utf-8").read()
+start_marker = "<script>window.MANIFEST = "
+start = content.index(start_marker) + len(start_marker)
+end = content.index(";</script>", start)
+payload = content[start:end]
+
+if "<" not in payload:
+    print("PASS: no raw angle bracket survives into the injected payload")
+else:
+    idx = payload.index("<")
+    print(f"FAIL: raw angle bracket in the injected payload — {payload[idx - 40:idx + 40]!r}")
+
+manifest = json.loads(payload)
+node = next((n for n in manifest.get("nodes", []) if n.get("path", "").endswith("hostile-template.md")), None)
+md = node.get("md", "") if node else ""
+if "<!--[if IE]><script src=" in md and "</script>" in md:
+    print("PASS: the escaped payload still parses back to the exact authored markdown, markup intact")
+else:
+    print(f"FAIL: markdown round-trip — got {md!r}")
+PYEOF
+)"
+echo "$hostile_py_out"
+pass_count=$((pass_count + $(echo "$hostile_py_out" | grep -c '^PASS:')))
+fail_count=$((fail_count + $(echo "$hostile_py_out" | grep -c '^FAIL:')))
+
 echo ""
 echo "----------------------------------------"
 echo "PASS: $pass_count  FAIL: $fail_count"

--- a/plugins/review-tools/skills/walkthrough/SKILL.md
+++ b/plugins/review-tools/skills/walkthrough/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: walkthrough
+description: Render a diagram-first, ordered-step HTML presentation that teaches how something works — or presents a technical-debt review, an areas-for-improvement pass, a set of recommendations, or a performance analysis. You investigate the code and author every word; a deterministic renderer turns your manifest into one self-contained page (vertical scroll by default, one button away from slide-by-slide). Self-contained output, no server, no CDN. Standalone — works in any repo, no other plugin required. Use when the owner needs to be walked through something in order, one idea at a time, rather than handed a diff or a reference page to navigate themselves.
+argument-hint: [what to walk through]
+---
+
+# walkthrough — a guided, diagram-first presentation of a subsystem or an analysis
+
+Renders a single, self-contained HTML file: a diagram up top, then an ordered sequence of narrated
+steps, each carrying one or more real code excerpts. No server, no CDN, opens correctly via
+`file://`. It defaults to vertical scroll and toggles, at runtime, to horizontal slide-by-slide
+navigation — the same generated file serves both, so nothing is regenerated to switch.
+
+**This is the sibling of `explain`, not a replacement for it.** `explain` reviews a *change* — a
+diff, an issue, a PR — as a file tree the owner navigates themselves. `walkthrough` presents a
+*narrative* about a topic, in an order you chose, when there is no diff to open it against. Reach
+for `explain` when the subject is "what changed"; reach for this when the subject is "how this
+works", "what's wrong with this", or "what we should do about it".
+
+## The load-bearing part: you author everything
+
+`generate-walkthrough.py` derives nothing. It never shells out to `git`, `gh`, or an AST tool; it
+validates your manifest and renders it, full stop. The diagram, the ordering, the narration, and
+every line of every excerpt are yours. That means the quality of the result is entirely a function
+of the investigation you do **before** writing the manifest:
+
+1. **Read the actual code first.** Follow the real path — entry point, the call it makes, where
+   state lands. Do not write a step from a filename or a guess.
+2. **Copy excerpts verbatim from the file, with their real line numbers.** The `path:startLine`
+   reference is a promise that the reader can open that file at that line and see exactly this.
+   Nothing checks it for you.
+3. **Decide the order deliberately.** A walkthrough's whole value is that step N+1 only makes sense
+   once step N has landed. If the steps could be read in any order, you have written a reference
+   page, not a walkthrough — use `explain` instead.
+4. **Then draw the diagram**, once you understand the shape well enough to draw it honestly.
+
+Keep it short. Five to nine steps is a walkthrough; twenty is a document nobody finishes.
+
+## Generating
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/walkthrough/scripts/generate-walkthrough.py \
+  --manifest <path.json> \
+  --out <path>
+```
+
+- `--manifest <path>` — **required**; the manifest JSON, the sole source of content.
+- `--out <path>` — output HTML path; defaults to a generated path under the system temp dir.
+- `--open` — additionally open the result in a browser. **Only pass this for an interactive,
+  same-machine, foreground invocation** — see the display constraint below.
+
+There is deliberately no `--title`/`--subtitle` flag: both live in the manifest, which is the one
+place content comes from.
+
+On success it always prints two lines: the absolute output path, then a literal `open <path>`
+line — regardless of whether `--open` was passed.
+
+## Manifest schema
+
+```
+title: string                   // required
+subtitle?: string
+diagram: {                       // required — a walkthrough always leads with a picture
+  type: "svg" | "html",           // required
+  source: string,                 // required, non-empty; inline markup, embedded as-is
+  caption?: string
+}
+steps: [                          // required, at least one
+  {
+    title: string,                // required
+    narration: string,            // required; markdown (headings, lists, code spans, fences, tables)
+    kind?: string,                // optional; renders a small badge. Any string is accepted.
+    excerpts: [                   // required, at least one
+      {
+        path: string,             // required; repo-relative path, as the reader would open it
+        startLine: number,        // required; the real first line number of this excerpt
+        endLine?: number,          // shown in the reference when given
+        code: string,              // required; the excerpt itself, verbatim
+        lang?: string,             // carried through as data-lang
+        highlight?: number[]       // absolute line numbers to visually distinguish
+      }
+    ]
+  }
+]
+```
+
+Validation is strict and loud — the generator writes no output file at all unless the whole
+manifest is valid. A missing/unreadable/empty manifest, a missing `title`, an empty `steps` list, a
+missing diagram or empty `diagram.source`, a step missing `title`/`narration`/a non-empty
+`excerpts` list, or an excerpt missing `path`/`startLine`/`code` each fail with a non-zero exit and
+a specific error. Step- and excerpt-level errors name the offending step by its 1-based position
+and title, and an excerpt error names the excerpt within it too.
+
+`kind` is deliberately **not** a closed enum: any string renders a badge, and an unrecognized value
+gets a neutral style rather than failing. The five conventional values below — spelled exactly as
+in the table — get their own color; anything else renders neutral.
+
+## The five kinds, and what a good one looks like
+
+Same schema, same renderer, no per-kind code path — only your content differs. Set each step's
+`kind` to the one it belongs to (a single walkthrough may legitimately mix them, e.g. an
+explanation that ends in two recommendations).
+
+| `kind` | The question the walkthrough answers | What the diagram should show | What each step's narration owes the reader |
+| --- | --- | --- | --- |
+| `explanation` | How does this work? | The real runtime shape: components and the direction data actually flows between them | Why the code does what it does, not a paraphrase of what it plainly says |
+| `tech-debt` | What's structurally wrong here? | The current shape, with the strain visible — the coupling, the duplication, the layer being bypassed | The concrete cost being paid today, and what makes it hard to change |
+| `improvements` | What could be better? | Current shape beside the shape you're proposing | The specific improvement, and what it buys — not a style preference |
+| `recommendation` | What should we do? | The end state being recommended | The recommendation, its trade-off, and what happens if it's skipped |
+| `performance` | Why is this slow? | The path with the hot spot marked — where time or allocations actually go | The measured or reasoned cost at that step, and what dominates |
+
+Two rules that apply to all five: **every step points at real code** (that's what `excerpts` is
+for — an assertion with no code under it is an opinion), and **name the cost, not just the
+smell** — "this is duplicated" is weak; "these two parsers drift, and the second one already
+missed the header fix in `ingest.py:20`" is a step worth reading.
+
+## Authoring the diagram
+
+Diagrams are inline markup you write, embedded verbatim. There is no Mermaid, no diagramming
+library, and no auto-layout — matching this plugin's "no framework, no external library"
+client-side convention.
+
+- **`type: "html"` is usually the easier one to get right**: a flex row of bordered boxes with
+  arrow characters between them is legible, hand-authorable, and hard to break. Prefer it unless
+  you specifically need geometry.
+- **`type: "svg"`** for anything with real layout — a branching flow, a layered stack. Use a
+  `viewBox` and keep it responsive; **omit `xmlns`** (inline SVG in HTML doesn't need it, and the
+  output must contain no URLs at all — see the self-containment rule below).
+- Style with plain inline styles or the shell's own CSS custom properties (`var(--accent)`,
+  `var(--text-dim)`, `var(--border)`), so the diagram matches the surrounding dark theme.
+- Keep it to the handful of boxes the walkthrough actually visits. The diagram is the map for
+  *these* steps, not an architecture poster.
+
+A worked `type: "html"` diagram — this is the pattern to start from, as it appears in the manifest
+(JSON, so the markup is one escaped string):
+
+```json
+"diagram": {
+  "type": "html",
+  "source": "<div style=\"display:flex;gap:10px;justify-content:center;align-items:center\"><span style=\"border:1px solid var(--border);border-radius:6px;padding:8px 14px\">Request</span><span style=\"color:var(--text-dim)\">&#8594;</span><span style=\"border:1px solid var(--accent);border-radius:6px;padding:8px 14px\">WidgetStore</span><span style=\"color:var(--text-dim)\">&#8594;</span><span style=\"border:1px solid var(--border);border-radius:6px;padding:8px 14px\">Cache</span></div>",
+  "caption": "A read goes through the store, which consults the cache before the database."
+}
+```
+
+Note the two things that carry the meaning: the box the walkthrough is *about* is bordered in
+`var(--accent)` while the supporting ones are in `var(--border)`, and the arrows are HTML entities
+(`&#8594;`), not characters that depend on the reader's font. For a branching or layered shape,
+switch to `type: "svg"` with a `viewBox` — same colors, same restraint.
+
+## Display constraint (load-bearing)
+
+A background/headless caller (a spawned agent process, a CI job) cannot reliably open a browser on
+the owner's screen — there is no display to open one on. The contract in that case is: **generate
+the file, print its absolute path plus an `open <path>` line, never assume a display.** `--open` is
+only for an interactive, same-machine, foreground invocation — e.g. the owner directly running
+`/walkthrough` themselves.
+
+## Rules
+
+- Never derive content mechanically and never guess it — read the code, then write the manifest.
+  Excerpts must be verbatim, with real line numbers, from the paths named.
+- Never ship a walkthrough whose steps could be read in any order. That's `explain`'s job.
+- Never pass `--open` from a background/headless caller — print the path + `open <path>` line
+  instead.
+- `generate-walkthrough.py` is stdlib-only (no pip dependencies, no `git`/`gh`, no network) and
+  must run on macOS system `python3` and in CI (Linux).
+- `assets/viewer.html` is a checked-in static shell — never edit it per-use. The generator injects
+  the manifest by replacing its single `<!--MANIFEST-->` marker; don't reproduce that literal
+  marker text anywhere else in the file (the generator's replace targets exactly one occurrence).
+- The output must stay self-contained: no `http://`, no `https://`, no `fetch(` — anywhere,
+  including inside your diagram markup and narration. No remote images, no linked stylesheets, no
+  fonts.
+- No interactivity beyond the layout toggle and its nav chrome (counter, prev/next, arrow keys).
+  There is no comment channel and no persistence — a static `file://` page has nothing to send
+  anything back to.
+
+## Testing
+
+`plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh` is a structural
+self-test — see `scripts/README.md` for what it checks and how to run it.

--- a/plugins/review-tools/skills/walkthrough/SKILL.md
+++ b/plugins/review-tools/skills/walkthrough/SKILL.md
@@ -126,6 +126,12 @@ client-side convention.
 - **`type: "svg"`** for anything with real layout — a branching flow, a layered stack. Use a
   `viewBox` and keep it responsive; **omit `xmlns`** (inline SVG in HTML doesn't need it, and the
   output must contain no URLs at all — see the self-containment rule below).
+- **`diagram.source` is embedded and executes as-is, with no sanitization, the instant the file
+  opens — no click required.** This is deliberate (it is the entire content model: agent-authored
+  markup, nothing mechanical in between), but it means the markup must be *yours* — never
+  interpolate text copied from the code, docs, issues, or dependencies under review into it. If
+  you need to show a fragment of real markup as an example, put it in a step's code excerpt
+  instead (rendered as inert text, not executed).
 - Style with plain inline styles or the shell's own CSS custom properties (`var(--accent)`,
   `var(--text-dim)`, `var(--border)`), so the diagram matches the surrounding dark theme.
 - Keep it to the handful of boxes the walkthrough actually visits. The diagram is the map for

--- a/plugins/review-tools/skills/walkthrough/SKILL.md
+++ b/plugins/review-tools/skills/walkthrough/SKILL.md
@@ -173,9 +173,15 @@ only for an interactive, same-machine, foreground invocation — e.g. the owner 
 - `assets/viewer.html` is a checked-in static shell — never edit it per-use. The generator injects
   the manifest by replacing its single `<!--MANIFEST-->` marker; don't reproduce that literal
   marker text anywhere else in the file (the generator's replace targets exactly one occurrence).
-- The output must stay self-contained: no `http://`, no `https://`, no `fetch(` — anywhere,
-  including inside your diagram markup and narration. No remote images, no linked stylesheets, no
-  fonts.
+- The output must stay self-contained: no remote images, no linked stylesheets, no fonts, no live
+  network reference anywhere. `generate-walkthrough.py` enforces this mechanically for
+  `diagram.source` (rejects `http://`/`https://`/`ftp://`/`ws(s)://` there — that is the one
+  field whose markup is embedded and executes as-is, so it is the one place a stray remote
+  reference would actually be live). Mentioning a URL as plain text in narration or a code
+  excerpt is fine — it renders as inert text, not a fetched resource, and is exempt from the
+  check on purpose (source code legitimately references URL constants). Nothing outside
+  `diagram.source` is mechanically checked, though: if you hand-author markup anywhere else that
+  could reference something remote, that is on you, not the tool.
 - No interactivity beyond the layout toggle and its nav chrome (counter, prev/next, arrow keys).
   There is no comment channel and no persistence — a static `file://` page has nothing to send
   anything back to.

--- a/plugins/review-tools/skills/walkthrough/assets/viewer.html
+++ b/plugins/review-tools/skills/walkthrough/assets/viewer.html
@@ -414,8 +414,16 @@
   // already-escapeHtml'd text (see inlineMD below), so scheme characters are all still
   // plain ASCII regardless of what the original URL contained.
   function isSafeLinkUrl(url) {
-    if (/^(https?:|mailto:)/i.test(url)) return true;
-    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url)) return false;
+    // Mirror what a browser's URL parser does before it ever looks at the scheme (WHATWG URL
+    // spec): strip leading/trailing C0-control-or-space, then remove every ASCII tab/newline
+    // from anywhere in the string. Skipping this lets a payload like "\x01javascript:..." or
+    // "java\tscript:..." slip through the checks below as "no explicit scheme" while a browser
+    // still strips the same characters and executes it as javascript: on click.
+    var normalized = url
+      .replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, "")
+      .replace(/[\t\n\r]/g, "");
+    if (/^(https?:|mailto:)/i.test(normalized)) return true;
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(normalized)) return false;
     return true;
   }
 

--- a/plugins/review-tools/skills/walkthrough/assets/viewer.html
+++ b/plugins/review-tools/skills/walkthrough/assets/viewer.html
@@ -1,0 +1,718 @@
+<title>Walkthrough</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    color-scheme: dark;
+    --bg: #1e1e1e;
+    --bg-panel: #252526;
+    --bg-header: #2d2d2d;
+    --bg-code: #161616;
+    --border: #3c3c3c;
+    --text: #d4d4d4;
+    --text-dim: #8a8a8a;
+    --accent: #569cd6;
+    --hover-bg: #2a2d2e;
+    --hl-bg: rgba(255, 213, 79, 0.14);
+    --diff-add-border: #2ea043;
+    --diff-del-border: #f85149;
+    --diff-sep: #6e7681;
+    --code-font: "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    --ui-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    height: 100%;
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--ui-font);
+  }
+
+  #app {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+  }
+
+  header#wt-header {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    background: var(--bg-header);
+    border-bottom: 1px solid var(--border);
+    padding: 10px 16px;
+  }
+
+  #wt-heading { flex: 1 1 auto; min-width: 0; }
+
+  header#wt-header h1 {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+  }
+
+  header#wt-header .subtitle {
+    margin-top: 2px;
+    font-size: 12.5px;
+    color: var(--text-dim);
+  }
+
+  /* ---------- nav chrome ---------- */
+
+  #nav {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  #nav button {
+    font-family: var(--ui-font);
+    font-size: 12px;
+    color: var(--text);
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 4px 10px;
+    cursor: pointer;
+  }
+
+  #nav button:hover { background: var(--hover-bg); }
+  #nav button:disabled { opacity: 0.4; cursor: default; }
+
+  #step-counter {
+    font-size: 12px;
+    color: var(--text-dim);
+    white-space: nowrap;
+    min-width: 92px;
+    text-align: center;
+  }
+
+  /* The counter and prev/next only steer horizontal mode; in vertical mode the page scrolls
+     normally, so they're hidden rather than lying about a position they don't control. */
+  #nav.vertical #step-counter,
+  #nav.vertical #prev-step,
+  #nav.vertical #next-step { display: none; }
+
+  /* ---------- content ---------- */
+
+  #content {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 20px 24px 40px;
+  }
+
+  #diagram-section {
+    max-width: 1100px;
+    margin: 0 auto 26px;
+    padding: 18px 20px;
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    text-align: center;
+  }
+
+  #diagram svg { max-width: 100%; height: auto; }
+
+  #diagram-caption {
+    margin-top: 12px;
+    font-size: 12.5px;
+    color: var(--text-dim);
+  }
+
+  #steps {
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .step {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px 20px 20px;
+  }
+
+  .step-head {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    margin-bottom: 6px;
+  }
+
+  .step-index {
+    font-family: var(--code-font);
+    font-size: 12px;
+    color: var(--text-dim);
+  }
+
+  .step-title {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+  }
+
+  /* Any string is accepted for a step's kind — the four conventional values get their own
+     color, anything else falls through to this neutral base style rather than failing. */
+  .step-kind {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: var(--diff-sep);
+    color: #1e1e1e;
+  }
+
+  .step-kind-explanation { background: var(--accent); }
+  .step-kind-tech-debt { background: #d29922; }
+  .step-kind-performance { background: #a371f7; }
+  .step-kind-recommendation { background: var(--diff-add-border); }
+
+  .step-narration { font-size: 13.5px; line-height: 1.55; }
+
+  /* ---------- code excerpts ---------- */
+
+  .excerpt { margin-top: 14px; }
+
+  .excerpt-ref {
+    font-family: var(--code-font);
+    font-size: 11.5px;
+    color: var(--text-dim);
+    padding: 4px 10px;
+    background: var(--bg-header);
+    border: 1px solid var(--border);
+    border-bottom: none;
+    border-radius: 6px 6px 0 0;
+  }
+
+  .excerpt-code {
+    font-family: var(--code-font);
+    font-size: 12.5px;
+    line-height: 1.5;
+    background: var(--bg-code);
+    border: 1px solid var(--border);
+    border-radius: 0 0 6px 6px;
+    overflow-x: auto;
+  }
+
+  .code-row { display: flex; white-space: pre; }
+  .code-row.hl { background: var(--hl-bg); }
+
+  .code-row .gl {
+    flex: 0 0 52px;
+    text-align: right;
+    padding: 0 8px;
+    color: var(--text-dim);
+    user-select: none;
+    border-right: 1px solid var(--border);
+  }
+
+  .code-row .code {
+    flex: 1 1 auto;
+    padding: 0 16px 0 8px;
+  }
+
+  /* ---------- horizontal (slide) mode ---------- */
+
+  #steps.horizontal {
+    flex-direction: row;
+    gap: 0;
+    max-width: none;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+  }
+
+  /* Bounded so a long step scrolls inside its own slide instead of stretching every slide to
+     its height and pushing the next one off-screen. */
+  #steps.horizontal > .step {
+    flex: 0 0 100%;
+    scroll-snap-align: start;
+    max-height: 70vh;
+    overflow-y: auto;
+  }
+
+  /* ---------- markdown (step narration) ---------- */
+
+  .step-narration h1, .step-narration h2, .step-narration h3,
+  .step-narration h4, .step-narration h5, .step-narration h6 {
+    color: var(--text);
+    margin: 1.1em 0 0.4em;
+    font-family: var(--ui-font);
+    font-size: 1.05em;
+  }
+
+  .step-narration p { margin: 0.5em 0; }
+
+  .step-narration ul, .step-narration ol {
+    margin: 0.4em 0;
+    padding-left: 1.6em;
+  }
+
+  .step-narration code {
+    font-family: var(--code-font);
+    background: rgba(110, 118, 129, 0.2);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.92em;
+  }
+
+  .step-narration pre.md-code {
+    background: var(--bg-code);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 14px;
+    overflow-x: auto;
+  }
+
+  .step-narration pre.md-code code { background: none; padding: 0; }
+
+  .step-narration a { color: var(--accent); }
+
+  .step-narration table {
+    border-collapse: collapse;
+    margin: 0.6em 0;
+    font-size: 0.95em;
+  }
+
+  .step-narration th, .step-narration td {
+    border: 1px solid var(--border);
+    padding: 4px 10px;
+    text-align: left;
+  }
+
+  .step-narration th { background: var(--bg-header); }
+
+  /* The copied markdown renderer color-codes OpenSpec's delta-spec sections; narration that
+     quotes one still renders styled rather than as a bare div. */
+  .delta-section {
+    border-left: 3px solid var(--diff-sep);
+    padding: 2px 0 2px 14px;
+    margin: 14px 0;
+  }
+  .delta-section .delta-label {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 1px 7px;
+    border-radius: 10px;
+    margin-bottom: 4px;
+  }
+  .delta-added { border-left-color: var(--diff-add-border); }
+  .delta-added .delta-label { background: var(--diff-add-border); color: #0a2e12; }
+  .delta-modified { border-left-color: #d29922; }
+  .delta-modified .delta-label { background: #d29922; color: #2b1d02; }
+  .delta-removed { border-left-color: var(--diff-del-border); }
+  .delta-removed .delta-label { background: var(--diff-del-border); color: #2e0a08; }
+  .delta-renamed { border-left-color: var(--accent); }
+  .delta-renamed .delta-label { background: var(--accent); color: #05203a; }
+</style>
+<div id="app">
+  <header id="wt-header">
+    <div id="wt-heading">
+      <h1 id="wt-title">Walkthrough</h1>
+      <div class="subtitle" id="wt-subtitle" style="display:none"></div>
+    </div>
+    <div id="nav" class="vertical">
+      <button id="prev-step" type="button" title="Previous step (left arrow)">&#8592; Prev</button>
+      <span id="step-counter">Step 1 of 1</span>
+      <button id="next-step" type="button" title="Next step (right arrow)">Next &#8594;</button>
+      <button id="layout-toggle" type="button">Slides</button>
+    </div>
+  </header>
+  <main id="content">
+    <section id="diagram-section">
+      <div id="diagram"></div>
+      <div id="diagram-caption" style="display:none"></div>
+    </section>
+    <div id="steps"></div>
+  </main>
+</div>
+<script>
+(function () {
+  "use strict";
+
+  // ---------------------------------------------------------------------
+  // Demo manifest — used only when window.MANIFEST is not injected (e.g.
+  // opening this shell file directly). generate-walkthrough.py replaces the
+  // injection marker near the end of this file with a real one (kept out of
+  // this comment as literal text so it stays a single, unique occurrence in
+  // this file for the generator to target).
+  // ---------------------------------------------------------------------
+  var DEMO_MANIFEST = {
+    title: "walkthrough viewer (demo)",
+    subtitle: "No manifest was injected — showing a built-in example.",
+    diagram: {
+      type: "html",
+      source: '<div style="display:flex;gap:10px;justify-content:center;align-items:center;font-family:monospace">' +
+        '<span style="border:1px solid #569cd6;border-radius:6px;padding:8px 14px">Request</span>' +
+        '<span style="color:#8a8a8a">&#8594;</span>' +
+        '<span style="border:1px solid #569cd6;border-radius:6px;padding:8px 14px">UserStore</span>' +
+        '<span style="color:#8a8a8a">&#8594;</span>' +
+        '<span style="border:1px solid #569cd6;border-radius:6px;padding:8px 14px">Cache</span>' +
+        "</div>",
+      caption: "A read goes through the store, which consults the cache first."
+    },
+    steps: [
+      {
+        title: "The entry point",
+        narration: "Every read enters through `get` — the **only** public accessor.",
+        kind: "explanation",
+        excerpts: [
+          {
+            path: "src/example/user_store.rs",
+            startLine: 10,
+            endLine: 12,
+            lang: "rust",
+            highlight: [11],
+            code: "pub fn get(&self, id: u64) -> Option<&User> {\n    self.users.get(&id)\n}"
+          }
+        ]
+      },
+      {
+        title: "The discarded return value",
+        narration: "`remove` throws away the removed `User`, so callers can't tell who was removed.",
+        kind: "tech-debt",
+        excerpts: [
+          {
+            path: "src/example/user_store.rs",
+            startLine: 14,
+            endLine: 16,
+            lang: "rust",
+            code: "pub fn remove(&mut self, id: u64) {\n    self.users.remove(&id);\n}"
+          }
+        ]
+      }
+    ]
+  };
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  // ---------------------------------------------------------------------
+  // Markdown — compact, built-in, no external library. Supports headings,
+  // ordered/unordered lists, fenced code blocks, inline code, bold, italic,
+  // links, and simple pipe tables. Copied verbatim from the explain skill's
+  // own viewer.html rather than written a second time; the two shells are
+  // separate static files with no build step to share JS through.
+  // ---------------------------------------------------------------------
+  function inlineMD(text) {
+    var s = escapeHtml(text);
+    var codes = [];
+    // Plain-ASCII sentinel (no control/unicode escapes) protects code-span content from the
+    // bold/italic/link passes below, then gets swapped back in as a real <code> tag.
+    s = s.replace(/`([^`]+)`/g, function (m, p1) {
+      codes.push(p1);
+      return "@@CS" + (codes.length - 1) + "@@";
+    });
+    s = s.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+    s = s.replace(/__([^_]+)__/g, "<strong>$1</strong>");
+    s = s.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+    s = s.replace(/_([^_]+)_/g, "<em>$1</em>");
+    s = s.replace(/@@CS(\d+)@@/g, function (m, idx) {
+      return "<code>" + codes[Number(idx)] + "</code>";
+    });
+    return s;
+  }
+
+  function splitTableRow(line) {
+    var t = line.trim();
+    if (t.charAt(0) === "|") t = t.slice(1);
+    if (t.charAt(t.length - 1) === "|") t = t.slice(0, -1);
+    return t.split("|").map(function (c) { return c.trim(); });
+  }
+
+  var TABLE_SEP_RE = /^\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/;
+  var HEADING_RE = /^(#{1,6})\s+(.*)$/;
+  var UL_RE = /^\s*[-*+]\s+(.*)$/;
+  var OL_RE = /^\s*\d+\.\s+(.*)$/;
+  var FENCE_RE = /^\s*(```|~~~)(.*)$/;
+
+  // OpenSpec's own delta-spec convention (not spec-flow-specific — OpenSpec is its own
+  // generic tool): a level-2 "## ADDED/MODIFIED/REMOVED/RENAMED Requirements" heading starts
+  // a section that runs until the next heading of level <= 2. Color-coded so new vs changed
+  // vs removed behavior is visually obvious while scrolling a delta spec, not just something
+  // you'd notice by reading a plain heading.
+  var DELTA_HEADING_RE = /^(ADDED|MODIFIED|REMOVED|RENAMED)\s+Requirements\b/i;
+
+  // Stable per-heading anchors (e.g. "requirement-widget-deletion") so a requirement/scenario can
+  // be referenced precisely — in a redirect, in a URL fragment — instead of "the third one down".
+  function slugify(text, usedIds) {
+    var base = String(text || "").toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "section";
+    var slug = base;
+    var n = 2;
+    while (usedIds[slug]) { slug = base + "-" + n; n++; }
+    usedIds[slug] = true;
+    return slug;
+  }
+
+  function renderMarkdown(src) {
+    var lines = String(src || "").replace(/\r\n/g, "\n").split("\n");
+    var html = "";
+    var i = 0;
+    var openDelta = null; // null | "added" | "modified" | "removed" | "renamed"
+    var usedIds = {};
+
+    while (i < lines.length) {
+      var line = lines[i];
+
+      var fence = line.match(FENCE_RE);
+      if (fence) {
+        var fenceMark = fence[1];
+        var lang = fence[2].trim();
+        var codeLines = [];
+        i++;
+        while (i < lines.length && lines[i].trim().indexOf(fenceMark) !== 0) {
+          codeLines.push(lines[i]);
+          i++;
+        }
+        i++; // skip closing fence
+        html += '<pre class="md-code"><code' +
+          (lang ? ' data-lang="' + escapeHtml(lang) + '"' : "") +
+          ">" + escapeHtml(codeLines.join("\n")) + "</code></pre>";
+        continue;
+      }
+
+      var heading = line.match(HEADING_RE);
+      if (heading) {
+        var level = heading[1].length;
+        var deltaMatch = level === 2 ? heading[2].trim().match(DELTA_HEADING_RE) : null;
+        if (level <= 2 && openDelta) {
+          html += "</div>";
+          openDelta = null;
+        }
+        if (deltaMatch) {
+          openDelta = deltaMatch[1].toLowerCase();
+          html += '<div class="delta-section delta-' + openDelta + '">' +
+            '<span class="delta-label">' + escapeHtml(deltaMatch[1].toUpperCase()) + "</span>";
+        }
+        var headingId = slugify(heading[2], usedIds);
+        html += "<h" + level + ' id="' + headingId + '">' + inlineMD(heading[2]) + "</h" + level + ">";
+        i++;
+        continue;
+      }
+
+      if (line.indexOf("|") !== -1 && i + 1 < lines.length && TABLE_SEP_RE.test(lines[i + 1])) {
+        var headerCells = splitTableRow(line);
+        i += 2;
+        var rows = [];
+        while (i < lines.length && lines[i].indexOf("|") !== -1 && !/^\s*$/.test(lines[i])) {
+          rows.push(splitTableRow(lines[i]));
+          i++;
+        }
+        html += "<table><thead><tr>" +
+          headerCells.map(function (c) { return "<th>" + inlineMD(c) + "</th>"; }).join("") +
+          "</tr></thead><tbody>" +
+          rows.map(function (r) {
+            return "<tr>" + r.map(function (c) { return "<td>" + inlineMD(c) + "</td>"; }).join("") + "</tr>";
+          }).join("") +
+          "</tbody></table>";
+        continue;
+      }
+
+      if (/^\s*$/.test(line)) { i++; continue; }
+
+      if (UL_RE.test(line)) {
+        var ulItems = [];
+        while (i < lines.length && UL_RE.test(lines[i])) {
+          ulItems.push(lines[i].replace(UL_RE, "$1"));
+          i++;
+        }
+        html += "<ul>" + ulItems.map(function (it) { return "<li>" + inlineMD(it) + "</li>"; }).join("") + "</ul>";
+        continue;
+      }
+
+      if (OL_RE.test(line)) {
+        var olItems = [];
+        while (i < lines.length && OL_RE.test(lines[i])) {
+          olItems.push(lines[i].replace(OL_RE, "$1"));
+          i++;
+        }
+        html += "<ol>" + olItems.map(function (it) { return "<li>" + inlineMD(it) + "</li>"; }).join("") + "</ol>";
+        continue;
+      }
+
+      var paraLines = [];
+      while (i < lines.length &&
+        !/^\s*$/.test(lines[i]) &&
+        !HEADING_RE.test(lines[i]) &&
+        !UL_RE.test(lines[i]) &&
+        !OL_RE.test(lines[i]) &&
+        !FENCE_RE.test(lines[i])) {
+        paraLines.push(lines[i]);
+        i++;
+      }
+      html += "<p>" + paraLines.map(inlineMD).join("<br>") + "</p>";
+    }
+
+    if (openDelta) html += "</div>";
+
+    return html;
+  }
+
+  // ---------------------------------------------------------------------
+  // Steps
+  // ---------------------------------------------------------------------
+  function kindClass(kind) {
+    // Any string is accepted (see SKILL.md): a recognized value gets its own color, anything
+    // else keeps the neutral base badge rather than being rejected.
+    var slug = String(kind).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+    return slug ? " step-kind-" + slug : "";
+  }
+
+  function renderExcerpt(excerpt) {
+    var startLine = Number(excerpt.startLine) || 1;
+    var ref = String(excerpt.path) + ":" + startLine +
+      (excerpt.endLine ? "-" + excerpt.endLine : "");
+    var highlightSet = {};
+    (excerpt.highlight || []).forEach(function (n) { highlightSet[n] = true; });
+
+    var rows = String(excerpt.code || "").replace(/\r\n/g, "\n").split("\n").map(function (line, idx) {
+      var lineNo = startLine + idx;
+      return '<div class="code-row' + (highlightSet[lineNo] ? " hl" : "") + '">' +
+        '<span class="gl">' + lineNo + "</span>" +
+        '<span class="code">' + escapeHtml(line) + "</span>" +
+        "</div>";
+    }).join("");
+
+    return '<div class="excerpt">' +
+      '<div class="excerpt-ref">' + escapeHtml(ref) + "</div>" +
+      '<div class="excerpt-code"' + (excerpt.lang ? ' data-lang="' + escapeHtml(excerpt.lang) + '"' : "") + ">" +
+      rows + "</div></div>";
+  }
+
+  function renderStep(step, index, total) {
+    var badge = step.kind
+      ? '<span class="step-kind' + kindClass(step.kind) + '">' + escapeHtml(step.kind) + "</span>"
+      : "";
+    return '<section class="step" data-step-index="' + index + '">' +
+      '<div class="step-head">' +
+      '<span class="step-index">' + (index + 1) + " / " + total + "</span>" +
+      '<h2 class="step-title">' + escapeHtml(step.title) + "</h2>" +
+      badge +
+      "</div>" +
+      '<div class="step-narration">' + renderMarkdown(step.narration) + "</div>" +
+      (step.excerpts || []).map(renderExcerpt).join("") +
+      "</section>";
+  }
+
+  // ---------------------------------------------------------------------
+  // App wiring
+  // ---------------------------------------------------------------------
+  function renderApp(manifest) {
+    var steps = manifest.steps || [];
+    var diagram = manifest.diagram || {};
+
+    document.getElementById("wt-title").textContent = manifest.title || "Walkthrough";
+    if (manifest.subtitle) {
+      var subtitleEl = document.getElementById("wt-subtitle");
+      subtitleEl.textContent = manifest.subtitle;
+      subtitleEl.style.display = "";
+    }
+
+    // The diagram is embedded as-authored (inline SVG or HTML markup) and always renders
+    // before any step content — that ordering is the whole point of this view.
+    document.getElementById("diagram").innerHTML = diagram.source || "";
+    if (diagram.caption) {
+      var captionEl = document.getElementById("diagram-caption");
+      captionEl.textContent = diagram.caption;
+      captionEl.style.display = "";
+    }
+
+    var stepsEl = document.getElementById("steps");
+    stepsEl.innerHTML = steps.map(function (step, i) {
+      return renderStep(step, i, steps.length);
+    }).join("");
+
+    var nav = document.getElementById("nav");
+    var counter = document.getElementById("step-counter");
+    var prevBtn = document.getElementById("prev-step");
+    var nextBtn = document.getElementById("next-step");
+    var toggle = document.getElementById("layout-toggle");
+    var current = 0;
+
+    function isHorizontal() { return stepsEl.classList.contains("horizontal"); }
+
+    function updateNav() {
+      counter.textContent = "Step " + (current + 1) + " of " + steps.length;
+      prevBtn.disabled = current === 0;
+      nextBtn.disabled = current >= steps.length - 1;
+    }
+
+    function goTo(index) {
+      if (!steps.length) return;
+      current = Math.min(Math.max(index, 0), steps.length - 1);
+      var slide = stepsEl.children[current];
+      if (slide) stepsEl.scrollLeft = slide.offsetLeft - stepsEl.offsetLeft;
+      updateNav();
+    }
+
+    // Vertical scroll is the default layout; the toggle flips a single class and CSS does the
+    // rest (scroll-snap), so one generated file serves both modes with no regeneration.
+    toggle.addEventListener("click", function () {
+      var horizontal = stepsEl.classList.toggle("horizontal");
+      nav.classList.toggle("vertical", !horizontal);
+      toggle.textContent = horizontal ? "Scroll" : "Slides";
+      if (horizontal) goTo(current);
+    });
+
+    prevBtn.addEventListener("click", function () { goTo(current - 1); });
+    nextBtn.addEventListener("click", function () { goTo(current + 1); });
+
+    document.addEventListener("keydown", function (ev) {
+      if (!isHorizontal()) return;
+      if (ev.key === "ArrowLeft") {
+        goTo(current - 1);
+        ev.preventDefault();
+      } else if (ev.key === "ArrowRight") {
+        goTo(current + 1);
+        ev.preventDefault();
+      }
+    });
+
+    // Keep the counter honest when the reader swipes/scrolls the slides directly instead of
+    // using the buttons.
+    stepsEl.addEventListener("scroll", function () {
+      if (!isHorizontal() || !stepsEl.clientWidth) return;
+      var index = Math.round(stepsEl.scrollLeft / stepsEl.clientWidth);
+      if (index !== current) {
+        current = Math.min(Math.max(index, 0), steps.length - 1);
+        updateNav();
+      }
+    });
+
+    updateNav();
+  }
+
+  function boot() {
+    renderApp(window.MANIFEST || DEMO_MANIFEST);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    // Marker script (if injected) already ran during synchronous parsing,
+    // and the document is already parsed by the time we get here.
+    boot();
+  }
+})();
+</script>
+<!--MANIFEST-->

--- a/plugins/review-tools/skills/walkthrough/assets/viewer.html
+++ b/plugins/review-tools/skills/walkthrough/assets/viewer.html
@@ -159,7 +159,7 @@
     font-weight: 600;
   }
 
-  /* Any string is accepted for a step's kind — the four conventional values get their own
+  /* Any string is accepted for a step's kind — the five conventional values get their own
      color, anything else falls through to this neutral base style rather than failing. */
   .step-kind {
     font-size: 10px;
@@ -174,6 +174,7 @@
 
   .step-kind-explanation { background: var(--accent); }
   .step-kind-tech-debt { background: #d29922; }
+  .step-kind-improvements { background: #56b6c2; }
   .step-kind-performance { background: #a371f7; }
   .step-kind-recommendation { background: var(--diff-add-border); }
 

--- a/plugins/review-tools/skills/walkthrough/assets/viewer.html
+++ b/plugins/review-tools/skills/walkthrough/assets/viewer.html
@@ -319,6 +319,9 @@
   .delta-renamed .delta-label { background: var(--accent); color: #05203a; }
 </style>
 <div id="app">
+  <div id="demo-fallback-banner" style="display:none;background:#f85149;color:#1e1e1e;font-weight:700;text-align:center;padding:8px 12px;font-family:sans-serif">
+    DEMO CONTENT — no manifest was injected into this file, so a built-in example is shown instead of a real walkthrough.
+  </div>
   <header id="wt-header">
     <div id="wt-heading">
       <h1 id="wt-title">Walkthrough</h1>
@@ -405,6 +408,17 @@
       .replace(/"/g, "&quot;");
   }
 
+  // A link target must be http(s)/mailto, or have no explicit scheme at all (relative,
+  // scheme-relative, fragment) -- narration is agent-authored, not sanitized, so a
+  // javascript:/data: URI must never become a click-to-execute anchor. Operates on
+  // already-escapeHtml'd text (see inlineMD below), so scheme characters are all still
+  // plain ASCII regardless of what the original URL contained.
+  function isSafeLinkUrl(url) {
+    if (/^(https?:|mailto:)/i.test(url)) return true;
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url)) return false;
+    return true;
+  }
+
   // ---------------------------------------------------------------------
   // Markdown — compact, built-in, no external library. Supports headings,
   // ordered/unordered lists, fenced code blocks, inline code, bold, italic,
@@ -421,7 +435,10 @@
       codes.push(p1);
       return "@@CS" + (codes.length - 1) + "@@";
     });
-    s = s.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    s = s.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, function (m, label, url) {
+      if (!isSafeLinkUrl(url)) return label + " (" + url + ")";
+      return '<a href="' + url + '" target="_blank" rel="noopener">' + label + "</a>";
+    });
     s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
     s = s.replace(/__([^_]+)__/g, "<strong>$1</strong>");
     s = s.replace(/\*([^*]+)\*/g, "<em>$1</em>");
@@ -704,6 +721,15 @@
   }
 
   function boot() {
+    // window.MANIFEST can be falsy either because nothing was injected (opening this shell
+    // directly, the documented DEMO_MANIFEST case) or because injection happened but the
+    // payload failed to parse (a future escaping regression, a truncated/mangled file) --
+    // either way, a reader must not mistake the demo content for a real walkthrough.
+    if (!window.MANIFEST) {
+      console.error("walkthrough: no manifest was injected (or it failed to parse) -- rendering built-in demo content instead");
+      var banner = document.getElementById("demo-fallback-banner");
+      if (banner) banner.style.display = "block";
+    }
     renderApp(window.MANIFEST || DEMO_MANIFEST);
   }
 

--- a/plugins/review-tools/skills/walkthrough/scripts/README.md
+++ b/plugins/review-tools/skills/walkthrough/scripts/README.md
@@ -1,0 +1,54 @@
+# walkthrough scripts
+
+- `generate-walkthrough.py` — deterministic renderer (an agent-authored manifest -> a
+  self-contained HTML presentation). Stdlib only; no pip deps, no `git`/`gh`, no network. See
+  `../SKILL.md` for the full CLI and manifest schema.
+- `test-generate-walkthrough.sh` — structural self-test for the script above and the viewer shell.
+- `fixtures/` — the manifests the test suite runs against: `valid.json` and `kinds.json` for the
+  happy paths, `script-data-content.json` for the injection-escaping regression, and one small
+  manifest per failure mode (empty, unparseable, no title, no diagram, empty diagram source,
+  unsupported diagram type, empty steps, a step missing its title or narration, a step with an
+  empty excerpt list, an excerpt missing its path/startLine/code, and a bad `highlight`). The
+  non-UTF-8 manifest case is built on the fly by the test itself rather than checked in as bytes.
+
+## Running the test
+
+```bash
+plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
+```
+
+No arguments, no network, no GitHub credentials, no `git` — it runs the generator against the
+checked-in `fixtures/` and asserts on the output HTML. Requires `python3`; bash 3.2 compatible
+otherwise (no associative arrays, no `mapfile`).
+
+What it checks:
+
+- a valid manifest exits 0 and produces an output file with no literal `<!--MANIFEST-->` left in it
+- the output contains no `http://`, `https://`, or `fetch(` substring (self-contained, no network)
+- the embedded `window.MANIFEST` JSON parses, and the title/subtitle, diagram (type, source,
+  caption), step order, per-step `kind`, and each excerpt's `path`/`startLine`/`endLine`/`code`/
+  `lang`/`highlight` all round-trip from the manifest
+- the diagram container precedes all step content in the rendered document
+- a `tech-debt`/`performance`/`recommendation` manifest renders through a **byte-identical** shell
+  to an `explanation` one — the assertion that there is no per-kind code path
+- an unrecognized `kind` string still renders rather than failing validation, and a step that omits
+  `kind` carries no badge
+- content that could break out of the injected `<script>` tag (an HTML-template excerpt containing
+  `<!--[if IE]><script>…</script>`) leaves no raw `<` in the injected payload, still parses back to
+  the exact authored code, and opens no extra script tag in the document
+- every failure mode exits non-zero and leaves **no output file behind**; the step- and
+  excerpt-level ones additionally name the offending step (1-based position + title) and the
+  excerpt within it in the error message
+
+It also greps `assets/viewer.html` for the structural markers a browser-side test would otherwise
+check — the `window.MANIFEST` reference and `DEMO_MANIFEST` fallback, the markdown renderer, the
+diagram/caption embedding, the kind badge, the `path:line` reference construction, `data-lang`, the
+`scroll-snap-type: x mandatory` horizontal layout, the toggle control and its `.horizontal` class
+flip, the counter, the prev/next buttons, and the `ArrowLeft`/`ArrowRight` keydown handler — plus
+the fact that the steps container ships **without** the `.horizontal` class, since vertical is the
+default. It also greps the shell itself for `http://`/`https://`/`fetch(`, so the `file://`-safety
+holds even before a manifest is injected. There's no headless browser available here, so the
+viewer's JS is checked for structure, not executed.
+
+Prints `PASS`/`FAIL` per assertion and a final tally; exits non-zero if anything failed, so it's
+usable as a CI check.

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/bad-diagram-type.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/bad-diagram-type.json
@@ -1,0 +1,11 @@
+{
+  "title": "Diagram with an unsupported type",
+  "diagram": { "type": "mermaid", "source": "graph TD; A-->B" },
+  "steps": [
+    {
+      "title": "A step",
+      "narration": "Some narration.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/bad-highlight.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/bad-highlight.json
@@ -1,0 +1,11 @@
+{
+  "title": "An excerpt's highlight is not a list of line numbers",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "The bad-highlight step",
+      "narration": "Its only excerpt highlights a string instead of a line number.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1", "highlight": "1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/diagram-ftp-scheme.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/diagram-ftp-scheme.json
@@ -1,0 +1,11 @@
+{
+  "title": "Diagram source references an ftp:// resource",
+  "diagram": { "type": "html", "source": "<img src=\"ftp://files.example.com/logo.png\">" },
+  "steps": [
+    {
+      "title": "A step",
+      "narration": "Narration.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/diagram-mixed-case-url.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/diagram-mixed-case-url.json
@@ -1,0 +1,11 @@
+{
+  "title": "Diagram source has a mixed-case URL scheme",
+  "diagram": { "type": "svg", "source": "<svg xmlns=\"HTTPS://www.w3.org/2000/svg\"></svg>" },
+  "steps": [
+    {
+      "title": "A step",
+      "narration": "Narration.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/empty-diagram-source.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/empty-diagram-source.json
@@ -1,0 +1,11 @@
+{
+  "title": "Diagram present but empty",
+  "diagram": { "type": "html", "source": "" },
+  "steps": [
+    {
+      "title": "A step",
+      "narration": "Some narration.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/empty-steps.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/empty-steps.json
@@ -1,0 +1,5 @@
+{
+  "title": "No steps at all",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": []
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-code-with-url.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-code-with-url.json
@@ -1,0 +1,18 @@
+{
+  "title": "An excerpt legitimately contains a URL",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "A step whose code references a URL constant",
+      "narration": "The excerpt below defines a URL constant -- this must not trip the self-containment check, which is scoped to diagram.source only.",
+      "excerpts": [
+        {
+          "path": "src/config.py",
+          "startLine": 1,
+          "lang": "python",
+          "code": "API_BASE = \"https://api.example.com/v1\""
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-endline-before-start.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-endline-before-start.json
@@ -1,0 +1,11 @@
+{
+  "title": "An excerpt has endLine before startLine",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "The backwards-range step",
+      "narration": "Its only excerpt claims lines 10 through 5, which is backwards.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 10, "endLine": 5, "code": "x = 1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-endline-zero.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-endline-zero.json
@@ -1,0 +1,11 @@
+{
+  "title": "An excerpt has endLine 0",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "The zero-endLine step",
+      "narration": "Its only excerpt claims an end line of 0, which does not exist.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 5, "endLine": 0, "code": "x = 1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-missing-code.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-missing-code.json
@@ -1,0 +1,11 @@
+{
+  "title": "An excerpt has no code",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "The codeless-excerpt step",
+      "narration": "Its only excerpt has no code.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1 }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-missing-path.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-missing-path.json
@@ -1,0 +1,19 @@
+{
+  "title": "Second excerpt of the second step has no path",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "A valid first step",
+      "narration": "Some narration.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }]
+    },
+    {
+      "title": "The pathless-excerpt step",
+      "narration": "Its second excerpt is missing a path.",
+      "excerpts": [
+        { "path": "src/a.py", "startLine": 2, "code": "y = 2" },
+        { "startLine": 3, "code": "z = 3" }
+      ]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-missing-startline.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-missing-startline.json
@@ -1,0 +1,11 @@
+{
+  "title": "An excerpt has no startLine",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "The startLine-less-excerpt step",
+      "narration": "Its only excerpt has no startLine.",
+      "excerpts": [{ "path": "src/a.py", "code": "x = 1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-startline-zero.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/excerpt-startline-zero.json
@@ -1,0 +1,11 @@
+{
+  "title": "An excerpt has startLine 0",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "The zero-startLine step",
+      "narration": "Its only excerpt claims line 0, which does not exist.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 0, "code": "x = 1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/kinds.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/kinds.json
@@ -1,0 +1,48 @@
+{
+  "title": "Ingest path review",
+  "diagram": {
+    "type": "svg",
+    "source": "<svg viewBox=\"0 0 200 40\" width=\"200\" height=\"40\"><rect x=\"1\" y=\"1\" width=\"198\" height=\"38\" fill=\"none\" stroke=\"#569cd6\"/><text x=\"12\" y=\"25\" fill=\"#d4d4d4\" font-size=\"13\">ingest -&gt; parse -&gt; store</text></svg>"
+  },
+  "steps": [
+    {
+      "title": "Duplicated parsing logic",
+      "narration": "The same header parse is implemented twice.",
+      "kind": "tech-debt",
+      "excerpts": [
+        { "path": "src/ingest.py", "startLine": 20, "code": "header = line.split(':', 1)" }
+      ]
+    },
+    {
+      "title": "The per-row allocation",
+      "narration": "Each row allocates a fresh buffer.",
+      "kind": "performance",
+      "excerpts": [
+        { "path": "src/ingest.py", "startLine": 55, "code": "buf = bytearray(4096)" }
+      ]
+    },
+    {
+      "title": "Batch the writes",
+      "narration": "Group writes into a single transaction.",
+      "kind": "recommendation",
+      "excerpts": [
+        { "path": "src/store.py", "startLine": 88, "code": "for row in rows:\n    self._db.insert(row)" }
+      ]
+    },
+    {
+      "title": "An unrecognized kind still renders",
+      "narration": "Any string is accepted for `kind`.",
+      "kind": "tech-dept",
+      "excerpts": [
+        { "path": "src/store.py", "startLine": 91, "code": "self._db.commit()" }
+      ]
+    },
+    {
+      "title": "No kind at all",
+      "narration": "This step omits `kind` entirely, so it must render no badge.",
+      "excerpts": [
+        { "path": "src/store.py", "startLine": 95, "code": "return len(rows)" }
+      ]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/no-diagram.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/no-diagram.json
@@ -1,0 +1,10 @@
+{
+  "title": "Diagram omitted entirely",
+  "steps": [
+    {
+      "title": "A step",
+      "narration": "Some narration.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/no-title.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/no-title.json
@@ -1,0 +1,10 @@
+{
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "A step",
+      "narration": "Some narration.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/not-an-object.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/not-an-object.json
@@ -1,0 +1,1 @@
+["this", "is", "an", "array", "not", "an", "object"]

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/not-json.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/not-json.json
@@ -1,0 +1,1 @@
+this is not JSON at all

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/script-data-content.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/script-data-content.json
@@ -1,0 +1,18 @@
+{
+  "title": "Content that could break out of the injected script tag",
+  "diagram": { "type": "html", "source": "<div>template -&gt; browser</div>" },
+  "steps": [
+    {
+      "title": "An HTML template excerpt",
+      "narration": "Narration mentioning `</script>` and a conditional comment.",
+      "excerpts": [
+        {
+          "path": "templates/legacy.html",
+          "startLine": 3,
+          "lang": "html",
+          "code": "<!--[if IE]><script src=\"shim.js\"></script><![endif]-->\n<div id=\"app\"></div>"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/step-empty-excerpts.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/step-empty-excerpts.json
@@ -1,0 +1,16 @@
+{
+  "title": "Second step has an empty excerpt list",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "A valid first step",
+      "narration": "Some narration.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }]
+    },
+    {
+      "title": "The excerptless step",
+      "narration": "Nothing to show.",
+      "excerpts": []
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/step-missing-narration.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/step-missing-narration.json
@@ -1,0 +1,15 @@
+{
+  "title": "Second step has no narration",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "A valid first step",
+      "narration": "Some narration.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }]
+    },
+    {
+      "title": "The narrationless step",
+      "excerpts": [{ "path": "src/a.py", "startLine": 2, "code": "y = 2" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/step-missing-title.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/step-missing-title.json
@@ -1,0 +1,15 @@
+{
+  "title": "Second step has no title",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    {
+      "title": "A valid first step",
+      "narration": "Some narration.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }]
+    },
+    {
+      "narration": "This one has no title.",
+      "excerpts": [{ "path": "src/a.py", "startLine": 2, "code": "y = 2" }]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/steps-wrong-type.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/steps-wrong-type.json
@@ -1,0 +1,5 @@
+{
+  "title": "steps is an object, not a list",
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": {}
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/title-wrong-type.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/title-wrong-type.json
@@ -1,0 +1,7 @@
+{
+  "title": 42,
+  "diagram": { "type": "html", "source": "<div>A -&gt; B</div>" },
+  "steps": [
+    { "title": "A step", "narration": "Narration.", "excerpts": [{ "path": "src/a.py", "startLine": 1, "code": "x = 1" }] }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/fixtures/valid.json
+++ b/plugins/review-tools/skills/walkthrough/scripts/fixtures/valid.json
@@ -1,0 +1,58 @@
+{
+  "title": "How the widget store loads",
+  "subtitle": "Three steps from request to cached row",
+  "diagram": {
+    "type": "html",
+    "source": "<div class=\"dg-row\"><span class=\"dg-box\">Request</span><span class=\"dg-arrow\">-&gt;</span><span class=\"dg-box\">WidgetStore</span><span class=\"dg-arrow\">-&gt;</span><span class=\"dg-box\">Cache</span></div>",
+    "caption": "A read goes through the store, which consults the cache before the database."
+  },
+  "steps": [
+    {
+      "title": "The entry point",
+      "narration": "Every read enters through `get`, which is the **only** public accessor.\n\nIt never touches the database directly.",
+      "kind": "explanation",
+      "excerpts": [
+        {
+          "path": "src/widget_store.py",
+          "startLine": 12,
+          "endLine": 15,
+          "lang": "python",
+          "code": "def get(self, widget_id):\n    cached = self._cache.get(widget_id)\n    if cached is not None:\n        return cached",
+          "highlight": [13]
+        }
+      ]
+    },
+    {
+      "title": "The cache miss path",
+      "narration": "On a miss the store falls through to the loader, then writes the result back.",
+      "excerpts": [
+        {
+          "path": "src/widget_store.py",
+          "startLine": 16,
+          "endLine": 18,
+          "lang": "python",
+          "code": "    row = self._loader.load(widget_id)\n    self._cache.put(widget_id, row)\n    return row"
+        },
+        {
+          "path": "src/loader.py",
+          "startLine": 40,
+          "lang": "python",
+          "code": "def load(self, widget_id):\n    return self._db.query(WIDGET_BY_ID, widget_id)"
+        }
+      ]
+    },
+    {
+      "title": "Where invalidation happens",
+      "narration": "Writes evict the entry rather than updating it in place.",
+      "kind": "tech-debt",
+      "excerpts": [
+        {
+          "path": "src/widget_store.py",
+          "startLine": 30,
+          "endLine": 32,
+          "code": "def save(self, widget):\n    self._db.upsert(widget)\n    self._cache.evict(widget.id)"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py
+++ b/plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py
@@ -78,7 +78,10 @@ def validate_diagram(diagram):
     # silently. Scoped to diagram.source only -- an excerpt's `code` legitimately contains URLs
     # (e.g. a URL constant in real source) and must stay exempt.
     source = diagram["source"]
-    if "http://" in source or "https://" in source:
+    # Case-insensitive: URL schemes are case-insensitive per RFC 3986, and editor
+    # autocapitalization/copy-paste can easily produce "HTTPS://" or "Http://".
+    source_lower = source.lower()
+    if "http://" in source_lower or "https://" in source_lower:
         fail("'diagram.source' contains an http:// or https:// reference — the rendered output "
              "must be fully self-contained (a common cause: an SVG's default xmlns attribute; "
              "see SKILL.md's authoring guidance to omit it)")
@@ -106,6 +109,13 @@ def validate_excerpt(excerpt, index, label):
         fail(f"{where}: missing required field 'startLine'")
     if isinstance(start_line, bool) or not isinstance(start_line, int):
         fail(f"{where}: 'startLine' must be an integer, got {type(start_line).__name__}")
+    if start_line < 1:
+        # Line numbers are 1-based -- 0 is not "unset" (that's what the field's absence already
+        # means, caught above) and negative is nonsensical. Reject here rather than let the
+        # viewer silently substitute a fallback: `Number(0) || 1`-style JS coercion would map
+        # startLine 0 to 1 with no error, quietly shifting the rendered gutter numbers by one
+        # and breaking every `highlight` entry that was written to line up with 0-based input.
+        fail(f"{where}: 'startLine' must be 1 or greater, got {start_line}")
 
     # The one optional field the viewer can't shrug off: it iterates `highlight` directly, so a
     # non-list here would blank the whole presentation at open time while this script still

--- a/plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py
+++ b/plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py
@@ -71,6 +71,17 @@ def validate_diagram(diagram):
     if diagram_type not in DIAGRAM_TYPES:
         fail(f"'diagram.type' must be one of {'/'.join(DIAGRAM_TYPES)}, got {diagram_type!r} — "
              "diagrams are agent-authored inline markup; no diagramming library is bundled")
+    # The one thing this validator can cheaply enforce for spec.md's self-contained-output
+    # requirement: a network reference in the diagram markup itself. The most common way this
+    # slips in is an SVG author's default xmlns attribute -- SKILL.md tells the agent to omit
+    # it, but nothing short of this check stops a non-conforming artifact from being produced
+    # silently. Scoped to diagram.source only -- an excerpt's `code` legitimately contains URLs
+    # (e.g. a URL constant in real source) and must stay exempt.
+    source = diagram["source"]
+    if "http://" in source or "https://" in source:
+        fail("'diagram.source' contains an http:// or https:// reference — the rendered output "
+             "must be fully self-contained (a common cause: an SVG's default xmlns attribute; "
+             "see SKILL.md's authoring guidance to omit it)")
 
 
 def step_label(index, step):
@@ -159,19 +170,26 @@ def main():
     viewer_path = Path(__file__).resolve().parent.parent / "assets" / "viewer.html"
     if not viewer_path.is_file():
         fail(f"viewer shell not found at {viewer_path} — was assets/viewer.html removed?")
-    viewer_html = viewer_path.read_text(encoding="utf-8")
+    try:
+        viewer_html = viewer_path.read_text(encoding="utf-8")
+    except OSError as e:
+        fail(f"couldn't read {viewer_path}: {e}")
 
     out_html = inject_manifest(viewer_html, manifest, PROG)
 
     out_path = Path(args.out).resolve() if args.out else default_out_path("walkthrough-")
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(out_html, encoding="utf-8")
+    try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(out_html, encoding="utf-8")
+    except OSError as e:
+        fail(f"couldn't write {out_path}: {e}")
 
     print(str(out_path))
     print(f"open {out_path}")
 
     if args.open:
-        webbrowser.open(f"file://{out_path}")
+        if not webbrowser.open(f"file://{out_path}"):
+            print(f"{PROG}: couldn't launch a browser — open the path above manually", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py
+++ b/plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py
@@ -79,12 +79,20 @@ def validate_diagram(diagram):
     # (e.g. a URL constant in real source) and must stay exempt.
     source = diagram["source"]
     # Case-insensitive: URL schemes are case-insensitive per RFC 3986, and editor
-    # autocapitalization/copy-paste can easily produce "HTTPS://" or "Http://".
+    # autocapitalization/copy-paste can easily produce "HTTPS://" or "Http://". Covers the
+    # common network schemes an SVG/HTML author might reference (an image src, a stylesheet
+    # link, a websocket) -- not exhaustive (e.g. a bare protocol-relative "//host/x" isn't
+    # checked, since that substring is common enough in ordinary prose/markup to risk false
+    # positives for a plain substring match), but covers every scheme spec.md's own
+    # self-contained-output scenario names plus the closely related ones an agent could
+    # plausibly reach for.
     source_lower = source.lower()
-    if "http://" in source_lower or "https://" in source_lower:
-        fail("'diagram.source' contains an http:// or https:// reference — the rendered output "
-             "must be fully self-contained (a common cause: an SVG's default xmlns attribute; "
-             "see SKILL.md's authoring guidance to omit it)")
+    network_schemes = ("http://", "https://", "ftp://", "ws://", "wss://")
+    hit = next((scheme for scheme in network_schemes if scheme in source_lower), None)
+    if hit:
+        fail(f"'diagram.source' contains a {hit!r} reference — the rendered output must be "
+             "fully self-contained (a common cause: an SVG's default xmlns attribute; see "
+             "SKILL.md's authoring guidance to omit it)")
 
 
 def step_label(index, step):

--- a/plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py
+++ b/plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Deterministic renderer for a `walkthrough` presentation: an agent-authored manifest (a diagram
+plus an ordered list of narrated steps) in, one self-contained HTML file out. Stdlib only (json,
+argparse, pathlib, webbrowser) — no pip dependencies, no `git`/`gh`, no network. Must run on macOS
+system python3 and in CI (Linux).
+
+Unlike generate-explain.py, this script derives NOTHING: it validates the manifest and injects it
+into the viewer shell, nothing more. Every byte of content — the diagram markup, each step's
+narration, each code excerpt — is written by the invoking agent. See
+plugins/review-tools/skills/walkthrough/SKILL.md for the manifest schema and authoring guidance.
+"""
+
+import argparse
+import functools
+import json
+import sys
+import webbrowser
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "lib"))
+from html_shell import default_out_path, inject_manifest  # noqa: E402
+from html_shell import fail as _fail  # noqa: E402
+
+PROG = "generate-walkthrough"
+fail = functools.partial(_fail, prog=PROG)
+
+DIAGRAM_TYPES = ("svg", "html")
+
+
+def load_manifest(path):
+    p = Path(path)
+    if not p.is_file():
+        fail(f"--manifest file not found: {path}")
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        fail(f"--manifest: couldn't read {path}: {e}")
+    if not text.strip():
+        fail(f"--manifest: {path} is empty — a walkthrough needs a diagram and at least one step")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        fail(f"--manifest: couldn't parse {path} as JSON: {e}")
+    if not isinstance(data, dict):
+        fail(f"--manifest: expected a JSON object at the top level, got {type(data).__name__}")
+    return data
+
+
+def require_text(value, what):
+    """The one shape check every required string field shares: present, a string, and not blank.
+    Returns an error phrase, or None when the value is fine."""
+    if value is None:
+        return f"missing required field {what}"
+    if not isinstance(value, str):
+        return f"{what} must be a string, got {type(value).__name__}"
+    if not value.strip():
+        return f"{what} is empty"
+    return None
+
+
+def validate_diagram(diagram):
+    if diagram is None:
+        fail("manifest is missing its required 'diagram' — a walkthrough always leads with a "
+             "diagram, never a bare list of steps")
+    if not isinstance(diagram, dict):
+        fail(f"'diagram' must be an object with 'type' and 'source', got {type(diagram).__name__}")
+    problem = require_text(diagram.get("source"), "'diagram.source'")
+    if problem:
+        fail(f"{problem} — there is nothing to draw")
+    diagram_type = diagram.get("type")
+    if diagram_type not in DIAGRAM_TYPES:
+        fail(f"'diagram.type' must be one of {'/'.join(DIAGRAM_TYPES)}, got {diagram_type!r} — "
+             "diagrams are agent-authored inline markup; no diagramming library is bundled")
+
+
+def step_label(index, step):
+    """"step 2 ('Wiring')" — the 1-based position always, plus the title when there is one to
+    quote. An error that only says "a step is invalid" is useless in a 12-step manifest."""
+    title = step.get("title") if isinstance(step, dict) else None
+    if isinstance(title, str) and title.strip():
+        return f"step {index} ({title.strip()!r})"
+    return f"step {index}"
+
+
+def validate_excerpt(excerpt, index, label):
+    where = f"{label}, excerpt {index}"
+    if not isinstance(excerpt, dict):
+        fail(f"{where}: must be an object, got {type(excerpt).__name__}")
+    for field in ("path", "code"):
+        problem = require_text(excerpt.get(field), f"'{field}'")
+        if problem:
+            fail(f"{where}: {problem}")
+    start_line = excerpt.get("startLine")
+    if start_line is None:
+        fail(f"{where}: missing required field 'startLine'")
+    if isinstance(start_line, bool) or not isinstance(start_line, int):
+        fail(f"{where}: 'startLine' must be an integer, got {type(start_line).__name__}")
+
+    # The one optional field the viewer can't shrug off: it iterates `highlight` directly, so a
+    # non-list here would blank the whole presentation at open time while this script still
+    # exited 0. Every other optional field renders harmlessly whatever its type.
+    highlight = excerpt.get("highlight")
+    if highlight is not None:
+        if not isinstance(highlight, list) or any(
+                isinstance(n, bool) or not isinstance(n, int) for n in highlight):
+            fail(f"{where}: 'highlight' must be a list of line numbers, got {highlight!r}")
+
+
+def validate_step(step, index):
+    label = step_label(index, step)
+    if not isinstance(step, dict):
+        fail(f"{label}: must be an object, got {type(step).__name__}")
+    for field in ("title", "narration"):
+        problem = require_text(step.get(field), f"'{field}'")
+        if problem:
+            fail(f"{label}: {problem}")
+    excerpts = step.get("excerpts")
+    if excerpts is None:
+        fail(f"{label}: missing required field 'excerpts' — every step shows at least one excerpt")
+    if not isinstance(excerpts, list):
+        fail(f"{label}: 'excerpts' must be a list, got {type(excerpts).__name__}")
+    if not excerpts:
+        fail(f"{label}: 'excerpts' is empty — every step shows at least one excerpt")
+    for i, excerpt in enumerate(excerpts, start=1):
+        validate_excerpt(excerpt, i, label)
+
+
+def validate(manifest, source_path):
+    problem = require_text(manifest.get("title"), "'title'")
+    if problem:
+        fail(f"manifest {problem}")
+    validate_diagram(manifest.get("diagram"))
+    steps = manifest.get("steps")
+    if steps is None:
+        fail("manifest is missing its required 'steps' list")
+    if not isinstance(steps, list):
+        fail(f"'steps' must be a list, got {type(steps).__name__}")
+    if not steps:
+        fail(f"--manifest: {source_path} has an empty 'steps' list — a walkthrough with no steps "
+             "is never worth rendering")
+    for i, step in enumerate(steps, start=1):
+        validate_step(step, i)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Render an agent-authored walkthrough manifest (diagram + ordered steps) as "
+                    "one self-contained HTML presentation.")
+    parser.add_argument("--manifest", required=True, metavar="PATH",
+                        help="the walkthrough manifest JSON — the sole source of content; this "
+                             "script derives nothing on its own")
+    parser.add_argument("--out", help="output HTML path (default: a generated path under the system temp dir)")
+    parser.add_argument("--open", action="store_true", help="open the result in a browser (only when explicitly passed)")
+    args = parser.parse_args()
+
+    manifest = load_manifest(args.manifest)
+    validate(manifest, args.manifest)
+
+    viewer_path = Path(__file__).resolve().parent.parent / "assets" / "viewer.html"
+    if not viewer_path.is_file():
+        fail(f"viewer shell not found at {viewer_path} — was assets/viewer.html removed?")
+    viewer_html = viewer_path.read_text(encoding="utf-8")
+
+    out_html = inject_manifest(viewer_html, manifest, PROG)
+
+    out_path = Path(args.out).resolve() if args.out else default_out_path("walkthrough-")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(out_html, encoding="utf-8")
+
+    print(str(out_path))
+    print(f"open {out_path}")
+
+    if args.open:
+        webbrowser.open(f"file://{out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py
+++ b/plugins/review-tools/skills/walkthrough/scripts/generate-walkthrough.py
@@ -125,6 +125,18 @@ def validate_excerpt(excerpt, index, label):
         # and breaking every `highlight` entry that was written to line up with 0-based input.
         fail(f"{where}: 'startLine' must be 1 or greater, got {start_line}")
 
+    # endLine is optional, but when given it hits the exact same falsy-zero trap startLine just
+    # got rejected for: the viewer renders it as `excerpt.endLine ? "-" + endLine : ""`, so an
+    # `endLine: 0` (or any falsy/wrong-typed value) would be silently treated as absent instead
+    # of failing loudly here.
+    end_line = excerpt.get("endLine")
+    if end_line is not None:
+        if isinstance(end_line, bool) or not isinstance(end_line, int):
+            fail(f"{where}: 'endLine' must be an integer, got {type(end_line).__name__}")
+        if end_line < start_line:
+            fail(f"{where}: 'endLine' ({end_line}) must be greater than or equal to 'startLine' "
+                 f"({start_line})")
+
     # The one optional field the viewer can't shrug off: it iterates `highlight` directly, so a
     # non-list here would blank the whole presentation at open time while this script still
     # exited 0. Every other optional field renders harmlessly whatever its type.

--- a/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
+++ b/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
@@ -354,6 +354,13 @@ expect_failure "an unparseable manifest file" "not-json.json"
 expect_failure "a manifest with an empty step list" "empty-steps.json" "steps"
 expect_failure "a manifest with no title" "no-title.json" "title"
 
+# Wrong-type input, not just missing/empty -- every failure fixture above tests a field being
+# ABSENT; these test a field being PRESENT with the wrong shape, a real mistake an
+# agent authoring a manifest by hand could easily make.
+expect_failure "a manifest that is a JSON array, not an object, at the top level" "not-an-object.json" "expected a JSON object" "list"
+expect_failure "a manifest whose title is a number, not a string" "title-wrong-type.json" "title" "must be a string" "int"
+expect_failure "a manifest whose steps is an object, not a list" "steps-wrong-type.json" "steps" "must be a list" "dict"
+
 # Diagram is mandatory.
 expect_failure "a manifest with no diagram at all" "no-diagram.json" "diagram"
 expect_failure "a diagram with an empty source" "empty-diagram-source.json" "diagram" "source"
@@ -383,6 +390,68 @@ expect_failure "an excerpt whose highlight isn't a list of line numbers" "bad-hi
 bad_bytes="$out_dir/bad-bytes.json"
 printf '{"title": "\377\376bad"}' > "$bad_bytes"
 expect_failure "a manifest that isn't valid UTF-8" "$bad_bytes" "couldn't read"
+
+# ---------------------------------------------------------------------------
+# Positive proof of the diagram-only self-containment scope: an excerpt's code legitimately
+# contains a URL and must be ACCEPTED, not just "not covered" by the diagram.source check. A
+# regression that broadened that check to the whole manifest would silently break ordinary
+# source code containing a URL constant, with nothing above to catch it.
+# ---------------------------------------------------------------------------
+code_url_html="$out_dir/walkthrough-code-url.html"
+python3 "$generate_walkthrough" --manifest "$fixtures/excerpt-code-with-url.json" --out "$code_url_html"
+check "an excerpt whose code contains a URL is accepted (self-containment is diagram-only)" $?
+
+grep -qF 'https://api.example.com/v1' "$code_url_html"
+check "the excerpt's URL survives into the rendered output" $?
+
+# ---------------------------------------------------------------------------
+# --open: both webbrowser.open() outcomes are part of the documented CLI contract (SKILL.md).
+# The $BROWSER env var is NOT a reliable cross-platform mock -- confirmed live, macOS routes
+# webbrowser.open() through its own AppleScript-based controller regardless of $BROWSER, so a
+# fake BROWSER=/usr/bin/false silently does nothing there. Monkeypatch webbrowser.open directly
+# instead, which is correct on every platform.
+# ---------------------------------------------------------------------------
+open_html="$out_dir/walkthrough-open.html"
+open_py_out="$(python3 - "$generate_walkthrough" "$fixtures/valid.json" "$open_html" <<'PYEOF'
+import importlib.util
+import io
+import sys
+import webbrowser
+
+script_path, manifest_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+spec = importlib.util.spec_from_file_location("generate_walkthrough_mod", script_path)
+gw = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gw)
+
+
+def run_with_open(open_returns):
+    webbrowser.open = lambda url: open_returns
+    saved_argv, saved_stderr = sys.argv, sys.stderr
+    sys.argv = ["generate-walkthrough.py", "--manifest", manifest_path, "--out", out_path, "--open"]
+    sys.stderr = io.StringIO()
+    try:
+        gw.main()
+        return sys.stderr.getvalue()
+    finally:
+        sys.argv, sys.stderr = saved_argv, saved_stderr
+
+
+stderr_on_success = run_with_open(True)
+if "couldn't launch" not in stderr_on_success:
+    print("PASS: --open with a successful browser launch prints no failure warning")
+else:
+    print(f"FAIL: --open success case unexpectedly warned — {stderr_on_success!r}")
+
+stderr_on_failure = run_with_open(False)
+if "couldn't launch a browser" in stderr_on_failure:
+    print("PASS: --open with a failed browser launch warns on stderr (exit still succeeds)")
+else:
+    print(f"FAIL: --open failure case did not warn — {stderr_on_failure!r}")
+PYEOF
+)"
+echo "$open_py_out"
+pass_count=$((pass_count + $(echo "$open_py_out" | grep -c '^PASS:')))
+fail_count=$((fail_count + $(echo "$open_py_out" | grep -c '^FAIL:')))
 
 echo ""
 echo "----------------------------------------"

--- a/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
+++ b/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
@@ -290,6 +290,21 @@ check "viewer.html defines a markdown-render function for step narration" $?
 grep -qE 'function inlineMD' "$viewer_html"
 check "viewer.html defines the inline-markdown helper" $?
 
+grep -qE 'function isSafeLinkUrl' "$viewer_html"
+check "viewer.html defines a link-scheme allow-list for narration markdown links" $?
+
+# The link-scheme check must normalize away leading/embedded control characters BEFORE testing
+# the scheme -- a browser's URL parser strips these too (WHATWG URL spec), so skipping this
+# normalization would let "\x01javascript:..." or "java\tscript:..." slip through as "no
+# explicit scheme" while a browser still executes them on click. No headless browser available
+# here, so this is a structural check (confirmed correct by direct evaluation during
+# development) rather than a live one -- see the surrounding function for the exact regexes.
+grep -qF '\x00-\x20' "$viewer_html"
+check "isSafeLinkUrl strips leading/trailing C0-control-or-space before checking the scheme" $?
+
+grep -qF '[\t\n\r]' "$viewer_html"
+check "isSafeLinkUrl strips embedded tab/newline before checking the scheme" $?
+
 grep -qF 'diagram.source' "$viewer_html"
 check "viewer.html embeds the diagram's source directly" $?
 
@@ -368,6 +383,9 @@ expect_failure "a diagram with an unsupported type" "bad-diagram-type.json" "dia
 # URL schemes are case-insensitive (RFC 3986) -- the self-containment check must not be fooled
 # by "HTTPS://" or "Http://" from editor autocapitalization or copy-paste.
 expect_failure "a diagram source with a mixed-case URL scheme" "diagram-mixed-case-url.json" "diagram.source" "http"
+# Not just http(s) -- other network schemes an agent might reach for (an image src, a
+# websocket) must be caught too, not just the two spec.md names explicitly.
+expect_failure "a diagram source with an ftp:// reference" "diagram-ftp-scheme.json" "diagram.source" "ftp"
 
 # Step-level failures name the offending step by 1-based position and title.
 expect_failure "a step missing its title" "step-missing-title.json" "step 2" "title"

--- a/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
+++ b/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
@@ -398,6 +398,10 @@ expect_failure "an excerpt missing its startLine" "excerpt-missing-startline.jso
 # startLine 0 (or negative) is not "unset" -- 0 must fail loudly, not silently become line 1 in
 # the viewer via a falsy-coercion fallback (the exact bug this rejects at generation time).
 expect_failure "an excerpt with startLine 0" "excerpt-startline-zero.json" "excerpt 1" "startLine" "1 or greater"
+# endLine hits the exact same falsy-zero trap startLine was just rejected for -- the viewer
+# treats a falsy endLine as "absent" via a ternary, so 0 must fail loudly here instead.
+expect_failure "an excerpt with endLine 0" "excerpt-endline-zero.json" "excerpt 1" "endLine"
+expect_failure "an excerpt whose endLine is before its startLine" "excerpt-endline-before-start.json" "excerpt 1" "endLine" "startLine"
 expect_failure "an excerpt missing its code" "excerpt-missing-code.json" "step 1" "The codeless-excerpt step" "excerpt 1" "code"
 
 # `highlight` is the one optional field the viewer iterates directly — a wrong type there would

--- a/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
+++ b/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
@@ -358,6 +358,9 @@ expect_failure "a manifest with no title" "no-title.json" "title"
 expect_failure "a manifest with no diagram at all" "no-diagram.json" "diagram"
 expect_failure "a diagram with an empty source" "empty-diagram-source.json" "diagram" "source"
 expect_failure "a diagram with an unsupported type" "bad-diagram-type.json" "diagram" "type"
+# URL schemes are case-insensitive (RFC 3986) -- the self-containment check must not be fooled
+# by "HTTPS://" or "Http://" from editor autocapitalization or copy-paste.
+expect_failure "a diagram source with a mixed-case URL scheme" "diagram-mixed-case-url.json" "diagram.source" "http"
 
 # Step-level failures name the offending step by 1-based position and title.
 expect_failure "a step missing its title" "step-missing-title.json" "step 2" "title"
@@ -367,6 +370,9 @@ expect_failure "a step with an empty excerpt list" "step-empty-excerpts.json" "s
 # Excerpt-level failures name BOTH the step and the excerpt within it.
 expect_failure "an excerpt missing its path" "excerpt-missing-path.json" "step 2" "The pathless-excerpt step" "excerpt 2" "path"
 expect_failure "an excerpt missing its startLine" "excerpt-missing-startline.json" "step 1" "The startLine-less-excerpt step" "excerpt 1" "startLine"
+# startLine 0 (or negative) is not "unset" -- 0 must fail loudly, not silently become line 1 in
+# the viewer via a falsy-coercion fallback (the exact bug this rejects at generation time).
+expect_failure "an excerpt with startLine 0" "excerpt-startline-zero.json" "excerpt 1" "startLine" "1 or greater"
 expect_failure "an excerpt missing its code" "excerpt-missing-code.json" "step 1" "The codeless-excerpt step" "excerpt 1" "code"
 
 # `highlight` is the one optional field the viewer iterates directly — a wrong type there would

--- a/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
+++ b/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+# Structural self-test for generate-walkthrough.py + viewer.html. Runs the generator against the
+# checked-in fixtures/ manifests and asserts on the output HTML — see README.md in this directory
+# for how to run it. Exits non-zero if any assertion fails. macOS bash 3.2 compatible (no
+# associative arrays, no mapfile); the JSON-shaped assertions delegate to python3, which the
+# generator itself already requires.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+generate_walkthrough="$script_dir/generate-walkthrough.py"
+viewer_html="$script_dir/../assets/viewer.html"
+fixtures="$script_dir/fixtures"
+
+pass_count=0
+fail_count=0
+
+check() {
+  # usage: check "<description>" <exit-status-where-0-is-pass>
+  local desc="$1"
+  local status="$2"
+  if [[ "$status" -eq 0 ]]; then
+    echo "PASS: $desc"
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL: $desc"
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+tally_py() {
+  # usage: tally_py "<python output>" — counts its PASS:/FAIL: lines into the running totals
+  local out="$1"
+  echo "$out"
+  pass_count=$((pass_count + $(echo "$out" | grep -c '^PASS:')))
+  fail_count=$((fail_count + $(echo "$out" | grep -c '^FAIL:')))
+}
+
+# usage: expect_failure "<description>" <fixture-or-empty> [expected substring...]
+# Asserts: non-zero exit, no output file produced, and (when given) each substring appears in
+# stderr. The fixture is a basename under fixtures/, or an absolute path for one built on the
+# fly; empty means "invoke with no --manifest at all".
+expect_failure() {
+  local desc="$1"
+  local fixture="$2"
+  shift 2
+
+  local err_file="$out_dir/err.txt"
+  local target="$out_dir/should-not-exist.html"
+  rm -f "$target"
+
+  local manifest_path="$fixtures/$fixture"
+  [[ "$fixture" == /* ]] && manifest_path="$fixture"
+
+  if [[ -n "$fixture" ]]; then
+    python3 "$generate_walkthrough" --manifest "$manifest_path" --out "$target" \
+      >/dev/null 2>"$err_file"
+  else
+    python3 "$generate_walkthrough" --out "$target" >/dev/null 2>"$err_file"
+  fi
+  local status=$?
+
+  [[ "$status" -ne 0 ]]
+  check "$desc -> non-zero exit" $?
+
+  [[ ! -f "$target" ]]
+  check "$desc -> no output file produced" $?
+
+  local needle
+  for needle in "$@"; do
+    # -e, so a needle that itself starts with "-" (e.g. "--manifest") isn't read as a grep flag
+    grep -qF -e "$needle" "$err_file"
+    check "$desc -> error message mentions '$needle'" $?
+  done
+}
+
+command -v python3 >/dev/null 2>&1 || { echo "test-generate-walkthrough: 'python3' is required but not on PATH." >&2; exit 1; }
+
+out_dir="$(mktemp -d)"
+out_html="$out_dir/walkthrough-test.html"
+cleanup() { rm -rf "$out_dir"; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Happy path: a valid multi-step manifest renders.
+# ---------------------------------------------------------------------------
+python3 "$generate_walkthrough" --manifest "$fixtures/valid.json" --out "$out_html"
+check "generate-walkthrough.py exits 0 on a valid manifest" $?
+
+[[ -f "$out_html" ]]
+check "output HTML file exists" $?
+
+if [[ -f "$out_html" ]]; then
+  ! grep -qF '<!--MANIFEST-->' "$out_html"
+  check "no literal <!--MANIFEST--> marker left in output" $?
+
+  ! grep -qE 'http://|https://|fetch\(' "$out_html"
+  check "no http(s):// or fetch( in output (self-contained)" $?
+else
+  check "no literal <!--MANIFEST--> marker left in output" 1
+  check "no http(s):// or fetch( in output (self-contained)" 1
+fi
+
+# ---------------------------------------------------------------------------
+# JSON-shaped assertions on the injected manifest: diagram present, steps in
+# the manifest's own order, excerpts and their file:line references intact.
+# ---------------------------------------------------------------------------
+tally_py "$(python3 - "$out_html" <<'PYEOF'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    content = open(path, encoding="utf-8").read()
+except OSError as e:
+    print(f"FAIL: could not read output HTML ({e})")
+    sys.exit(0)
+
+start_marker = "<script>window.MANIFEST = "
+try:
+    start = content.index(start_marker) + len(start_marker)
+    end = content.index(";</script>", start)
+    manifest = json.loads(content[start:end])
+    print("PASS: embedded window.MANIFEST JSON parses")
+except Exception as e:
+    print(f"FAIL: embedded window.MANIFEST JSON parses ({e})")
+    sys.exit(0)
+
+if manifest.get("title") == "How the widget store loads" and manifest.get("subtitle"):
+    print("PASS: title/subtitle round-trip from the manifest")
+else:
+    print(f"FAIL: title/subtitle — got {manifest.get('title')!r}/{manifest.get('subtitle')!r}")
+
+diagram = manifest.get("diagram") or {}
+if diagram.get("type") == "html" and "WidgetStore" in diagram.get("source", "") and diagram.get("caption"):
+    print("PASS: diagram (type, source, caption) round-trips from the manifest")
+else:
+    print(f"FAIL: diagram round-trip — got {diagram!r}")
+
+steps = manifest.get("steps", [])
+titles = [s.get("title") for s in steps]
+if titles == ["The entry point", "The cache miss path", "Where invalidation happens"]:
+    print("PASS: steps render in the exact order given in the manifest")
+else:
+    print(f"FAIL: step order — got {titles}")
+
+# The diagram must precede ALL step content in the document, not just in the manifest: the
+# shell renders #diagram before #steps, and the injected payload keeps that structure.
+diagram_pos = content.find('id="diagram"')
+steps_pos = content.find('id="steps"')
+if diagram_pos != -1 and steps_pos != -1 and diagram_pos < steps_pos:
+    print("PASS: the diagram container precedes all step content in the rendered document")
+else:
+    print(f"FAIL: diagram/steps document order — diagram@{diagram_pos}, steps@{steps_pos}")
+
+second = steps[1] if len(steps) > 1 else {}
+excerpts = second.get("excerpts", [])
+if len(excerpts) == 2 and excerpts[0]["path"] == "src/widget_store.py" and excerpts[1]["path"] == "src/loader.py":
+    print("PASS: a step carries more than one excerpt, in order")
+else:
+    print(f"FAIL: multi-excerpt step — got {excerpts!r}")
+
+first_excerpt = (steps[0].get("excerpts") or [{}])[0]
+if (first_excerpt.get("path") == "src/widget_store.py" and first_excerpt.get("startLine") == 12
+        and first_excerpt.get("endLine") == 15 and "def get" in first_excerpt.get("code", "")):
+    print("PASS: an excerpt's code and its path/startLine/endLine reference travel together")
+else:
+    print(f"FAIL: excerpt file:line reference — got {first_excerpt!r}")
+
+if first_excerpt.get("lang") == "python" and first_excerpt.get("highlight") == [13]:
+    print("PASS: optional excerpt lang/highlight round-trip")
+else:
+    print(f"FAIL: excerpt lang/highlight — got {first_excerpt.get('lang')!r}/{first_excerpt.get('highlight')!r}")
+
+if steps[0].get("kind") == "explanation" and "kind" not in steps[1]:
+    print("PASS: kind is carried when present and absent when omitted")
+else:
+    print(f"FAIL: kind presence — got {steps[0].get('kind')!r} / {'kind' in steps[1]}")
+PYEOF
+)"
+
+# ---------------------------------------------------------------------------
+# Content-agnostic across walkthrough kinds: a tech-debt/performance/
+# recommendation manifest goes through the exact same renderer, and an
+# unrecognized kind string still renders rather than failing validation.
+# ---------------------------------------------------------------------------
+kinds_html="$out_dir/walkthrough-kinds.html"
+python3 "$generate_walkthrough" --manifest "$fixtures/kinds.json" --out "$kinds_html"
+check "a non-'how it works' manifest (tech-debt/performance/recommendation) exits 0" $?
+
+tally_py "$(python3 - "$out_html" "$kinds_html" <<'PYEOF'
+import json
+import sys
+
+
+def read(path):
+    content = open(path, encoding="utf-8").read()
+    start = content.index("<script>window.MANIFEST = ") + len("<script>window.MANIFEST = ")
+    end = content.index(";</script>", start)
+    return content, json.loads(content[start:end])
+
+
+explanation_content, explanation = read(sys.argv[1])
+kinds_content, kinds = read(sys.argv[2])
+
+kind_values = [s.get("kind") for s in kinds.get("steps", [])]
+if kind_values == ["tech-debt", "performance", "recommendation", "tech-dept", None]:
+    print("PASS: every kind value (including an unrecognized one) survives validation unchanged")
+else:
+    print(f"FAIL: kind values — got {kind_values}")
+
+# Same code path: strip the injected payload from both outputs; the remaining shell must be
+# byte-identical, proving no per-kind rendering branch exists in the generator.
+def shell_only(content):
+    start = content.index("<script>window.MANIFEST = ")
+    end = content.index(";</script>", start) + len(";</script>")
+    return content[:start] + content[end:]
+
+
+if shell_only(explanation_content) == shell_only(kinds_content):
+    print("PASS: an explanation and a tech-debt/performance walkthrough render through the identical shell (no per-kind code path)")
+else:
+    print("FAIL: per-kind rendering divergence between the two outputs")
+
+if kinds.get("diagram", {}).get("type") == "svg":
+    print("PASS: an svg diagram is accepted alongside html")
+else:
+    print(f"FAIL: svg diagram — got {kinds.get('diagram')!r}")
+PYEOF
+)"
+
+# ---------------------------------------------------------------------------
+# Content that could break out of the injected <script> tag. An excerpt from an
+# HTML template is ordinary input for this tool, and "<!--" followed by
+# "<script" puts HTML's script-data tokenizer into double-escaped state — after
+# which a later "</script>" no longer closes the tag and the page silently
+# renders the shell's demo fallback instead of the real walkthrough.
+# ---------------------------------------------------------------------------
+hostile_html="$out_dir/walkthrough-script-data.html"
+python3 "$generate_walkthrough" --manifest "$fixtures/script-data-content.json" --out "$hostile_html"
+check "a manifest containing </script> and a conditional comment exits 0" $?
+
+tally_py "$(python3 - "$hostile_html" <<'PYEOF'
+import json
+import sys
+
+content = open(sys.argv[1], encoding="utf-8").read()
+start_marker = "<script>window.MANIFEST = "
+start = content.index(start_marker) + len(start_marker)
+end = content.index(";</script>", start)
+payload = content[start:end]
+
+if "<" not in payload:
+    print("PASS: no raw '<' survives into the injected payload (script-data tokenizer can't be re-entered)")
+else:
+    print(f"FAIL: raw '<' in the injected payload — {payload[payload.index('<') - 40:payload.index('<') + 40]!r}")
+
+manifest = json.loads(payload)
+code = manifest["steps"][0]["excerpts"][0]["code"]
+if code.startswith("<!--[if IE]><script src=") and "</script>" in code:
+    print("PASS: the escaped payload still parses back to the exact authored code, markup intact")
+else:
+    print(f"FAIL: code round-trip — got {code!r}")
+
+# The shell's own <script> plus the injected one, and nothing the content opened.
+if content.count("<script>") == 2:
+    print("PASS: content markup never opens an extra script tag in the rendered document")
+else:
+    print(f"FAIL: unexpected <script> count — {content.count('<script>')}")
+PYEOF
+)"
+
+# ---------------------------------------------------------------------------
+# Structural checks on the static viewer shell itself — no headless browser
+# available here, so this greps for the branches/handlers a browser test would
+# otherwise exercise, the same convention test-generate-explain.sh uses.
+# ---------------------------------------------------------------------------
+grep -qF 'window.MANIFEST' "$viewer_html"
+check "viewer.html references window.MANIFEST" $?
+
+grep -qF 'DEMO_MANIFEST' "$viewer_html"
+check "viewer.html has a DEMO_MANIFEST fallback for opening the shell directly" $?
+
+grep -qE 'function renderMarkdown' "$viewer_html"
+check "viewer.html defines a markdown-render function for step narration" $?
+
+grep -qE 'function inlineMD' "$viewer_html"
+check "viewer.html defines the inline-markdown helper" $?
+
+grep -qF 'diagram.source' "$viewer_html"
+check "viewer.html embeds the diagram's source directly" $?
+
+grep -qF 'diagram.caption' "$viewer_html"
+check "viewer.html renders the diagram caption when given" $?
+
+grep -qF 'step-kind' "$viewer_html"
+check "viewer.html renders a per-step kind badge" $?
+
+grep -qE 'step\.kind' "$viewer_html"
+check "viewer.html branches on the optional step.kind (omitted -> no badge)" $?
+
+grep -qF '":" + ' "$viewer_html"
+check "viewer.html builds each excerpt's file:line source reference" $?
+
+grep -qF 'excerpt-code' "$viewer_html"
+check "viewer.html renders excerpt code blocks" $?
+
+grep -qF 'data-lang' "$viewer_html"
+check "viewer.html carries an excerpt's lang through as data-lang" $?
+
+grep -qF 'scroll-snap-type: x mandatory' "$viewer_html"
+check "viewer.html switches to horizontal via CSS scroll-snap, no JS animation" $?
+
+grep -qF 'id="layout-toggle"' "$viewer_html"
+check "viewer.html ships the runtime layout toggle control" $?
+
+grep -qF 'classList.toggle("horizontal")' "$viewer_html"
+check "the toggle flips a .horizontal class on the steps container (and back)" $?
+
+grep -qF 'id="step-counter"' "$viewer_html"
+check "viewer.html has a step counter" $?
+
+grep -qF 'id="prev-step"' "$viewer_html" && grep -qF 'id="next-step"' "$viewer_html"
+check "viewer.html has prev/next buttons" $?
+
+grep -qF 'ArrowLeft' "$viewer_html" && grep -qF 'ArrowRight' "$viewer_html"
+check "viewer.html handles left/right keyboard navigation" $?
+
+grep -qE 'addEventListener\("keydown"' "$viewer_html"
+check "viewer.html registers a keydown handler for arrow navigation" $?
+
+# Vertical is the DEFAULT: the shipped steps container must carry no .horizontal class until
+# the toggle is used, and the CSS must define the horizontal variant separately.
+! grep -qE '<div id="steps"[^>]*class="[^"]*horizontal' "$viewer_html"
+check "the steps container starts WITHOUT the .horizontal class (vertical by default)" $?
+
+grep -qE '#steps\.horizontal' "$viewer_html"
+check "horizontal layout is a CSS variant of the same container, not a separate artifact" $?
+
+! grep -qE 'http://|https://|fetch\(' "$viewer_html"
+check "viewer.html shell itself has no http(s):// or fetch( (file://-safe)" $?
+
+# ---------------------------------------------------------------------------
+# Loud failure: no manifest, an empty/unparseable manifest, or a manifest with
+# no steps must exit non-zero and never leave an output file behind.
+# ---------------------------------------------------------------------------
+expect_failure "no --manifest at all" "" "--manifest"
+expect_failure "a nonexistent manifest path" "does-not-exist.json" "not found"
+expect_failure "an empty manifest file" "empty.json"
+expect_failure "an unparseable manifest file" "not-json.json"
+expect_failure "a manifest with an empty step list" "empty-steps.json" "steps"
+expect_failure "a manifest with no title" "no-title.json" "title"
+
+# Diagram is mandatory.
+expect_failure "a manifest with no diagram at all" "no-diagram.json" "diagram"
+expect_failure "a diagram with an empty source" "empty-diagram-source.json" "diagram" "source"
+expect_failure "a diagram with an unsupported type" "bad-diagram-type.json" "diagram" "type"
+
+# Step-level failures name the offending step by 1-based position and title.
+expect_failure "a step missing its title" "step-missing-title.json" "step 2" "title"
+expect_failure "a step missing its narration" "step-missing-narration.json" "step 2" "The narrationless step" "narration"
+expect_failure "a step with an empty excerpt list" "step-empty-excerpts.json" "step 2" "The excerptless step" "excerpts"
+
+# Excerpt-level failures name BOTH the step and the excerpt within it.
+expect_failure "an excerpt missing its path" "excerpt-missing-path.json" "step 2" "The pathless-excerpt step" "excerpt 2" "path"
+expect_failure "an excerpt missing its startLine" "excerpt-missing-startline.json" "step 1" "The startLine-less-excerpt step" "excerpt 1" "startLine"
+expect_failure "an excerpt missing its code" "excerpt-missing-code.json" "step 1" "The codeless-excerpt step" "excerpt 1" "code"
+
+# `highlight` is the one optional field the viewer iterates directly — a wrong type there would
+# blank the rendered presentation while the generator still exited 0.
+expect_failure "an excerpt whose highlight isn't a list of line numbers" "bad-highlight.json" "excerpt 1" "highlight"
+
+# A manifest that isn't valid UTF-8 is an unreadable manifest, not a traceback.
+bad_bytes="$out_dir/bad-bytes.json"
+printf '{"title": "\377\376bad"}' > "$bad_bytes"
+expect_failure "a manifest that isn't valid UTF-8" "$bad_bytes" "couldn't read"
+
+echo ""
+echo "----------------------------------------"
+echo "PASS: $pass_count  FAIL: $fail_count"
+
+if [[ "$fail_count" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
+++ b/plugins/review-tools/skills/walkthrough/scripts/test-generate-walkthrough.sh
@@ -249,10 +249,13 @@ start = content.index(start_marker) + len(start_marker)
 end = content.index(";</script>", start)
 payload = content[start:end]
 
-if "<" not in payload:
-    print("PASS: no raw '<' survives into the injected payload (script-data tokenizer can't be re-entered)")
+lt = "<"
+script_open = "<script>"
+if lt not in payload:
+    print("PASS: no raw angle bracket survives into the injected payload (script-data tokenizer cannot be re-entered)")
 else:
-    print(f"FAIL: raw '<' in the injected payload — {payload[payload.index('<') - 40:payload.index('<') + 40]!r}")
+    idx = payload.index(lt)
+    print(f"FAIL: raw angle bracket in the injected payload - {payload[idx - 40:idx + 40]!r}")
 
 manifest = json.loads(payload)
 code = manifest["steps"][0]["excerpts"][0]["code"]
@@ -261,11 +264,12 @@ if code.startswith("<!--[if IE]><script src=") and "</script>" in code:
 else:
     print(f"FAIL: code round-trip — got {code!r}")
 
-# The shell's own <script> plus the injected one, and nothing the content opened.
-if content.count("<script>") == 2:
+# The viewer shell has its own <script> plus the injected one, and nothing the content opened.
+script_count = content.count(script_open)
+if script_count == 2:
     print("PASS: content markup never opens an extra script tag in the rendered document")
 else:
-    print(f"FAIL: unexpected <script> count — {content.count('<script>')}")
+    print(f"FAIL: unexpected <script> count — {script_count}")
 PYEOF
 )"
 


### PR DESCRIPTION
Closes #42

## What this adds

A new `walkthrough` skill in `review-tools`, alongside `explain`: an agent-authored, diagram-first,
ordered-step code presentation, rendered as one self-contained HTML file (no server, no CDN, opens
via `file://`). Covers explanation, tech-debt review, areas-for-improvement, recommendations, and
performance analysis through the same manifest schema and renderer — only the authored content
differs. Vertical scroll by default, a runtime toggle to horizontal slide-by-slide navigation
(step counter, prev/next, keyboard arrows).

Also extracts three genuinely-identical helpers (`fail()`, the `<!--MANIFEST-->` injection helper,
the temp-output-path helper) out of `explain`'s generator into a small shared
`plugins/review-tools/lib/html_shell.py`, both tools now import from it.

## Review process — worth knowing about before reading the commit history

Team mode's review-panel agent dispatch turned out to be broken in this environment: every spawn
(bare-name and `spec-flow:`-prefixed alike) silently resolved to `project-manager` instead of the
intended specialized lens, rather than erroring. That's a real bug I'll file separately. The
sessions that hit this were honest about the mismatch and did real work anyway by reading the
target agent's own definition and following its process — so the substance was usable, just not
through the intended mechanism. Once I recognized the pattern, the two- and three-round follow-up
correctness/test-rigor passes ran through the built-in `/code-review` skill directly (which does
work reliably) and a fresh non-team `test-rigor` agent.

Net effect: this went through five real review rounds instead of the usual one-to-three, each
finding fewer and more subtle issues, converging (the last two passes found nothing caused by the
fixes themselves). Real things found and fixed along the way:

- **A real bash 3.2 bug** that silently killed ~60 of the walkthrough suite's assertions on macOS
  system bash (an apostrophe inside a heredoc nested in `$(...)` — a known bash 3.2 parser quirk).
  Only looked green locally because Homebrew bash was earlier in `$PATH`. Everything from here on
  was re-verified under real `/bin/bash` (3.2.57), not just whatever `bash` resolves to.
- **A real XSS**, twice: the markdown link renderer initially had no scheme allow-list
  (`javascript:`/`data:` links were click-to-execute), and the first fix for that was itself
  bypassable via a leading control character or embedded tab (browsers strip those before parsing
  the scheme; the regex didn't, per WHATWG URL semantics). Both closed.
- **A silent-wrong-content bug**: if the injected manifest ever failed to parse, the viewer quietly
  rendered demo content with zero diagnostic — a reviewer could mistake it for the real thing. Now
  logs to console and shows a visible banner.
- **Two falsy-zero bugs** (`startLine: 0` and, found in a later pass, the identical gap for
  `endLine`) silently mis-rendering line references instead of failing loudly.
- Unguarded output-side file writes, a discarded `--open` browser-launch failure, an incomplete/
  case-sensitive self-containment check (now catches `ftp://`/`ws(s)://` too, case-insensitively),
  a documentation claim that overstated what's actually enforced, and a handful of real
  antagonistic test-coverage gaps (wrong-type inputs, an unproven exemption, both `--open`
  outcomes untested).

Full account, task by task, is in `openspec/changes/issue-42/tasks.md` sections 7–13.

**Deliberately not fixed here** (flagged for separate triage, pre-existing in `explain`, outside
this change's scope): `generate-explain.py` has the identical unguarded-write and
discarded-`webbrowser.open()` gaps this diff fixed in the new tool, and the identical
missing-link-scheme-allow-list gap — fed genuinely untrusted GitHub content there, arguably higher
priority than the copy in this diff.

## Testing

`test-generate-walkthrough.sh`: 151/151. `test-generate-explain.sh`: 88/88 (85 pre-existing + 3 new
— a dedicated regression case for the shared escaping fix). Both suites run to completion locally,
verified under both the default `bash` and the real macOS system `/bin/bash` (3.2.57) explicitly —
there's no separate unit/integration tier or CI-only suite in this repo; these bash scripts are the
full local gate, and this PR's own CI run exercises the same ones.

## Still open

- `plugins/review-tools/.claude-plugin/plugin.json`'s version is still `0.12.0` (task 6.1,
  deliberately deferred) — this repo's convention is to confirm the exact bump with the owner
  before changing it. Propose **0.13.0** (minor, per the repo's stated default) unless you'd
  rather something else.
