### PR TITLE
board.py: report backlog/epics as counts, recommend only unowned work

### DIFF
--- a/openspec/changes/issue-46/.openspec.yaml
+++ b/openspec/changes/issue-46/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/issue-46/ac-coverage.md
+++ b/openspec/changes/issue-46/ac-coverage.md
@@ -1,0 +1,22 @@
+| Source | Requirement | Covering scenario(s) | Status |
+|--------|-------------|----------------------|--------|
+| AC | 15 ungroomed issues report as a count, with no ungroomed row rendered | `delivery-board: A large ungroomed backlog` | ✅ Covered |
+| AC | Board length does not vary with backlog size | `delivery-board: Backlog size does not change board length` | ✅ Covered |
+| AC | No BLOCKED ON YOU header when nothing is blocked on the owner | `delivery-board: No issues are waiting on the owner` | ✅ Covered |
+| AC | No archive line and no `specs pending archive: 0` when nothing is pending | `delivery-board: Nothing is pending archive` | ✅ Covered |
+| AC | "Next up" names the P0 issue when unclaimed ready issues exist at P0 and P2 | `delivery-board: Several ready issues at different priorities` | ✅ Covered |
+| AC | No "next up" line when no unclaimed ready issue exists, even with a non-empty backlog | `delivery-board: No ready issues exist`; `delivery-board: The backlog is the only work available` | ✅ Covered |
+| AC | "Next up" never recommends merging a green in-review PR, in any liveness state | `delivery-board: A green PR is waiting on the owner's review` | ✅ Covered |
+| AC | A parked `needs-attention` issue renders under BLOCKED ON YOU but is not named by "next up" | `delivery-board: An agent is stopped waiting on the owner` | ✅ Covered |
+| AC | Archive suggestion renders with its count when specs are pending | `delivery-board: Specs are pending archive` | ✅ Covered |
+| AC | A `P1` row shows `1️⃣`, not the text `P1` | `delivery-board: A prioritized issue renders` | ✅ Covered |
+| AC | Prioritized and unprioritized rows in one section stay column-aligned | `delivery-board: An unprioritized issue renders alongside prioritized ones` | ✅ Covered |
+| AC | Blocked/needs-attention notes render with the same content as before the prefetch change | `delivery-board: Blocked/needs-attention notes render unchanged` | ✅ Covered |
+| AC | A failed `gh issue view --json comments` call falls back to `"see issue comments"` for that row alone | `delivery-board: One issue's comment fetch fails during the concurrent prefetch` | ✅ Covered |
+| AC | `test-board.sh` exits 0 after the change | `delivery-board: Test suite passes after the change` | ✅ Covered |
+| Retained scope | `render_board()` structured as one function per section | `delivery-board: A section with no content contributes no lines` | ✅ Covered |
+| Risk (re-scope) | The original invariance requirement — "next up reads the full backlog, never the capped view" — was unfalsifiable: `backlog` is sorted by (priority, number) before any cap applies, so the top row is always inside it | — | ⚠️ Removed — the requirement, its scenario and its two assertions are deleted. "Next up" no longer reads the backlog at all, so the property has nothing left to describe |
+| Risk (re-scope) | Deleting the BACKLOG section leaves no view of ungroomed work until a backlog agent exists | — | ⚠️ Accepted — owner is grooming interactively for now; a backlog agent and its view are explicitly out of scope for this issue |
+| Risk (rendering) | A keycap emoji is three codepoints but renders in ~2 cells, so `f"{p:3}"` padding misaligns every row | `delivery-board: An unprioritized issue renders alongside prioritized ones` (tasks.md 6.2 states the mechanism) | ✅ Covered |
+| Risk (rendering) | Removing sections could leave stray blank lines where a section used to emit its trailing `""` | `delivery-board: No issues are waiting on the owner` (asserts absence of the header, not just its rows) | ✅ Covered |
+| Risk (regression) | `main`'s `test-board.sh` is shellcheck-clean; the branch's was not | — | ✅ Covered — tasks.md 7.11 makes a clean `shellcheck` run part of the definition of done |

--- a/openspec/changes/issue-46/design.md
+++ b/openspec/changes/issue-46/design.md
@@ -1,0 +1,136 @@
+# Design — board presentation
+
+## Context
+
+This design replaces the one that shipped with the first implementation of issue 46. That design
+capped the BACKLOG section's rows and each epic's sub-issue list, with a `--full` flag to disable
+both. It is recorded here in outline because the reason it failed is the reason this design has
+the shape it does.
+
+## D1. Why capping was the wrong lever
+
+Two symptoms, one cause.
+
+**The cap needed exceptions.** "Next up" had to read past it, EPICS needed a separate cap with
+different semantics, and `--full` had to undo both. Each exception is a place the board's output
+stops meaning one thing.
+
+**One exception was unfalsifiable.** The spec required that capping "never changes which issue
+next up recommends". No implementation could violate it: `backlog` is sorted by
+`(priority_key, number)` before any cap is applied, and the cap takes a prefix, so the
+top-priority row is always inside the displayed set. The requirement described a bug that the sort
+order already made unreachable — and the two tests written for it would have passed whether or not
+the cap leaked into the recommendation.
+
+The cause underneath both: the board rendered two categories with opposite growth from one
+function. Delivery state is bounded by the pipeline — an issue only reaches `status:in-progress`
+because an agent is driving it, and there is a small ceiling on how many run at once. The
+ungroomed backlog is bounded by nothing and grows forever. Capping was an attempt to make the
+second fit beside the first.
+
+## D2. Counts, not caps
+
+An unbounded category is reported as a number. Bounded categories render their rows.
+
+| category | growth | rendering |
+|---|---|---|
+| blocked on you, in flight, ready | bounded by the pipeline | rows |
+| ungroomed backlog, epics | unbounded | count only |
+
+This removes the cap, the `--full` flag, the `capped()` helper and the invariance requirement in
+one move, because none of them has anything left to act on. It also makes a property the caps
+could only approximate exactly true: **the board's rendered length no longer varies with the size
+of the backlog.** That is the property worth testing, and it is the one the spec now states.
+
+## D3. Every line is conditional
+
+No header, count, or suggestion renders unless it has content. A section with nothing to report
+contributes zero lines — not a header with nothing beneath it, and not a `blocked: 0` entry in the
+summary.
+
+The consequence worth stating: an absent line is information. When the archive suggestion is on
+screen there is something to archive; when it is absent there is not. A board that renders
+`specs pending archive: 0` forces the reader to parse a number to learn nothing happened.
+
+The failure mode to watch is stray whitespace. Each existing section appends a trailing `""` after
+its rows to separate itself from the next. A section that returns early must not leave that blank
+line behind, or removing sections produces a board with growing gaps where content used to be.
+Hence the spec's scenario asserts absence of the *header*, not merely absence of rows.
+
+## D4. The board reports; it does not direct owned work
+
+"Next up" previously recommended four things. Three of them named an issue that already had an
+agent driving it:
+
+- **merge this green PR** — that issue's `issue-manager` is alive and parked at Seam 2. It is
+  already waiting to tell the owner exactly this.
+- **unblock this** — likewise; the agent posted the `🆘` comment that the board is reading.
+- **groom this backlog issue** — the backlog's own job, not the delivery board's.
+
+Only the fourth — activate an unclaimed `status:ready` issue — names work with no owner at all.
+That is the one that survives, and it is the whole of "next up" now: highest priority first, P0
+through P3, and silence when there is nothing.
+
+The distinction is between reporting and directing. BLOCKED ON YOU keeps rendering its rows,
+because *discovering* which of several background sessions wants you is cross-issue information no
+single `issue-manager` can provide. What it stops doing is telling the owner to act on an issue
+another agent owns.
+
+A rejected alternative: gate the merge recommendation on the liveness marker, showing it only when
+a row is 🔴 (no `agent:active` label, so nothing is driving it). This was rejected because it is
+right for the wrong reason — it would make the recommendation *accurate* while leaving the board
+in the business of directing work it does not own. It also cannot be made correct: an
+`issue-manager` that dies uncleanly never removes its label, so an abandoned issue sits 🟡
+indefinitely and never reaches 🔴.
+
+## D5. Keycap priority rendering
+
+`P0`–`P3` render as `0️⃣`–`3️⃣`.
+
+One implementation hazard, because the board is column-aligned plain text: a keycap emoji is three
+codepoints — the digit, U+FE0F, and U+20E3 — so Python counts `"1️⃣"` as length 3 while a terminal
+draws it in roughly two cells. The existing `f"{row['priority'] or '--':3}"` would therefore pad
+every prioritized row differently from every unprioritized one, and the columns after it would
+drift.
+
+The fix is to stop using format-width padding for this field: emit the keycap followed by a
+literal space, and a fixed-width blank of matching display width when an issue has no priority
+label. All four keycaps are the same width, so alignment holds without measurement.
+
+## D6. Retained from the first implementation
+
+Three pieces survive the re-scope, and are already implemented and tested on the branch.
+
+- **Concurrent comment prefetch** (`prefetch_notes()`) — orthogonal to rendering; it changes when
+  `gh` calls happen, not what is printed.
+- **Per-row failure isolation**, including `json.JSONDecodeError` handling — same.
+- **`render_board()` decomposed into one function per section** — this one earns its place here
+  rather than merely surviving. Conditional rendering (D3) is a per-section decision; with one
+  function per section each decides for itself and returns nothing when it has nothing. Inlined in
+  a single function, the same behavior is a thicket of nested conditionals around a shared `out`
+  list, which is what the original code was.
+
+Its requirement did change: the decomposition no longer promises byte-for-byte identical output,
+because the output is deliberately changing now. It promises structure — one function per section,
+so a section's presence is decided in one place.
+
+## D7. Explicitly out of scope
+
+- **Bounding what the board retrieves.** `ISSUE_LIMIT` and pagination are untouched; that is a
+  real concern but a different one, and it needs GraphQL pagination.
+
+  The one fetch edit this change does make is subtractive, and follows from the rendering change
+  rather than reopening the fetch question: with epics reporting as a count, nothing reads the
+  `subIssues` node list, so it leaves the `--json` field list along with the three dead row keys
+  it fed. `subIssuesSummary` stays — `is_epic` tests its `total`. Keeping a query field that no
+  code reads would have been the pin producing a worse result than the rule it protects.
+
+  Note also that a fetch bound would not reduce context cost: `board.py` is a script, and only its
+  stdout enters a model's context — the raw JSON never does. Rendering is the only lever on
+  tokens, which is why this change is a rendering change.
+- **A separate backlog agent** and the view that would serve it. The owner is grooming
+  interactively for now. The accepted consequence is that this board shows a count where it used
+  to show rows, with no replacement view yet.
+- **Autopilot** — automatically serving or starting the top ready item, and the conflict detection
+  that would require. The conflict question already has machinery worth reusing (the
+  backlog-overlap search `project-manager` runs at spawn time), but none of it belongs here.

--- a/openspec/changes/issue-46/overrides.md
+++ b/openspec/changes/issue-46/overrides.md
@@ -1,0 +1,10 @@
+## Overrides existing behavior
+
+None — this change only adds new requirements. `delivery-board` is a new capability; no baseline
+spec exists at `openspec/specs/delivery-board/` for it to modify or remove.
+
+## Conflicts with other in-flight changes
+
+None found. Two other open changes exist (`issue-42` touching `walkthrough`,
+`openspec-aware-explain-view` touching `explain`); neither touches `board.py` or the new
+`delivery-board` capability.

--- a/openspec/changes/issue-46/proposal.md
+++ b/openspec/changes/issue-46/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+`board.py` renders one board for two audiences with opposite needs. Delivery state — what is in
+flight, what is waiting on the owner — is small, bounded by the pipeline itself, and is what the
+owner actually reads. The ungroomed backlog is unbounded, grows forever, and is a different job
+entirely. Rendering both inline means the second crowds out the first: on the repo today the board
+prints 22 lines, 12 of which are a backlog dump, and `board/SKILL.md` has the calling model print
+that stdout verbatim as its own reply — so the text lands in context twice per invocation and
+persists in session history.
+
+The earlier version of this change tried to fix that by capping the backlog's rendered rows. That
+was the wrong lever. A cap needs exceptions to stay correct — "next up" must read past it, EPICS
+needs a different one, `--full` must undo it — and each exception is a place the board contradicts
+itself. The change carried a requirement stating that capping "never changes which issue next up
+recommends", which no implementation could violate, because the backlog is sorted before the cap
+is applied. An unfalsifiable requirement is a sign the design is working around itself.
+
+The board does not need a smaller backlog rendering. It needs to stop rendering the backlog and
+report a count instead.
+
+A second, unrelated defect: "next up" recommends actions on issues that already have an owner —
+telling the owner to merge a PR that a live `issue-manager` is already parked on at Seam 2, or to
+unblock an issue whose own agent is waiting to tell them the same thing. The board does not drive
+issues; it reports on them.
+
+## What Changes
+
+- Replace the BACKLOG and EPICS sections with counts in a single summary line. Neither renders
+  per-issue rows.
+- Render every section conditionally: a header, count, or suggestion appears only when it has
+  content. Nothing renders to fill a slot, and no section prints a zero.
+- Narrow "next up" to a single case — the highest-priority unclaimed `status:ready` issue, P0
+  before P1 before P2 before P3. Remove the merge-a-green-PR, unblock, and groom-the-backlog
+  recommendations: each names an issue that already has an owner driving it.
+- Suggest an action only when it is actionable. `/spec-flow:archive` appears when specs are
+  pending and is absent otherwise, rather than reporting `specs pending archive: 0`.
+- Render priority as a keycap digit (`P1` → `1️⃣`) rather than the literal label text.
+- Keep BLOCKED ON YOU rendering its rows unchanged. It reports which background sessions want the
+  owner, which is cross-issue discovery no single `issue-manager` can provide. It no longer feeds
+  "next up".
+- Keep the concurrent comment prefetch, its per-row failure isolation, and the `render_board()`
+  decomposition from the earlier revision of this change. The decomposition earns its place here:
+  conditional per-section rendering is materially cleaner with one function per section.
+
+## Capabilities
+
+### New Capabilities
+- `delivery-board`: `board.py`'s deterministic rendering of the delivery board — bucketing issues
+  by lifecycle status, reporting unbounded categories as counts, recommending only unowned work,
+  and prefetching comment-derived notes concurrently. No existing capability spec covers
+  `board.py`; this is its first.
+
+### Modified Capabilities
+(none — `delivery-board` is new)
+
+## Impact
+
+- `plugins/spec-flow/scripts/board.py` — BACKLOG and EPICS section renderers replaced by summary
+  counts; `compute_next_up()` reduced to the ready-issue case and no longer takes
+  `blocked_on_you` or `backlog`; conditional suggestion rendering; keycap priority formatting;
+  `render_board()` decomposed into per-section functions; `prefetch_notes()` and the broadened
+  exception handling in `last_comment_matching()` retained.
+- `plugins/spec-flow/scripts/test-board.sh` — fixtures and assertions updated to the new render.
+- `plugins/spec-flow/skills/board/SKILL.md` — the bucket list drops BACKLOG and EPICS, and the
+  judgment step conditional on a backlog groom recommendation is removed as unreachable.
+- Out of scope, and unchanged: `ISSUE_LIMIT`, pagination, and how many issues the board retrieves.
+  The one fetch-layer edit is subtractive — `subIssues` leaves the `--json` field list because
+  nothing reads it once epics stop rendering sub-issue rows. `subIssuesSummary` stays; `is_epic`
+  reads it.

--- a/openspec/changes/issue-46/specs/delivery-board/spec.md
+++ b/openspec/changes/issue-46/specs/delivery-board/spec.md
@@ -1,0 +1,130 @@
+## ADDED Requirements
+
+### Requirement: Unbounded categories report as counts, never as rows
+The system SHALL report the ungroomed backlog and the epic list as counts in the board's summary
+line, and SHALL NOT render a per-issue row for either. The board's rendered length SHALL NOT grow
+with the size of the backlog or the number of epics.
+
+#### Scenario: A large ungroomed backlog
+- **WHEN** `board.py` renders a repo with 15 ungroomed issues
+- **THEN** the summary line reports `15 ungroomed` and no ungroomed issue is rendered as its own
+  row
+
+#### Scenario: Backlog size does not change board length
+- **WHEN** `board.py` renders the same repo state twice, differing only in the number of
+  ungroomed issues
+- **THEN** both renders produce the same number of lines
+
+### Requirement: Every section renders only when it has content
+The system SHALL render a section header, a count, or a suggested action only when that element
+has content to report. The system SHALL NOT render an empty section, a zero count, or a
+placeholder line standing in for absent content.
+
+#### Scenario: No issues are waiting on the owner
+- **WHEN** no issue is blocked on the owner
+- **THEN** the BLOCKED ON YOU header does not appear at all, rather than appearing with no rows
+  beneath it
+
+#### Scenario: Nothing is pending archive
+- **WHEN** no OpenSpec changes are pending archive
+- **THEN** no archive line and no `specs pending archive: 0` text appears anywhere in the output
+
+### Requirement: "Next up" names only unclaimed ready work, in priority order
+The system SHALL recommend at most one issue under "next up", and SHALL draw that recommendation
+only from issues carrying the `status:ready` label with no assignee. The system SHALL order those
+candidates by priority label, P0 before P1 before P2 before P3, with unprioritized issues last.
+
+#### Scenario: Several ready issues at different priorities
+- **WHEN** unclaimed `status:ready` issues exist at P2 and P0
+- **THEN** "next up" names the P0 issue
+
+#### Scenario: No ready issues exist
+- **WHEN** no unclaimed `status:ready` issue exists
+- **THEN** no "next up" line is rendered at all
+
+### Requirement: "Next up" never recommends an issue that already has an owner
+The system SHALL NOT recommend merging a pull request, unblocking a stopped agent, or grooming a
+backlog issue under "next up". Each of those names work already driven by another agent — an
+issue's own `issue-manager`, or the backlog's — and the board reports state rather than directing
+work it does not drive.
+
+#### Scenario: A green PR is waiting on the owner's review
+- **WHEN** an issue is `status:in-review` with a green PR awaiting the owner
+- **THEN** "next up" does not recommend merging it, regardless of whether that issue's
+  `issue-manager` session is live, stalled, or absent
+
+#### Scenario: The backlog is the only work available
+- **WHEN** no unclaimed `status:ready` issue exists and the backlog is non-empty
+- **THEN** "next up" recommends nothing, rather than falling back to a grooming suggestion
+
+### Requirement: BLOCKED ON YOU reports rows without recommending them
+The system SHALL continue to render a row for each issue blocked on the owner, including its
+attach instruction, PR and CI state, and liveness marker. That section SHALL NOT feed the "next
+up" recommendation.
+
+#### Scenario: An agent is stopped waiting on the owner
+- **WHEN** an issue carries `needs-attention` and its agent is parked
+- **THEN** its row renders under BLOCKED ON YOU with its attach instruction, and "next up" does
+  not name it
+
+### Requirement: Suggested actions are conditional on being actionable
+The system SHALL render a suggested command only when the condition it addresses currently holds.
+
+#### Scenario: Specs are pending archive
+- **WHEN** one or more OpenSpec changes are pending archive
+- **THEN** the board renders a `/spec-flow:archive` suggestion naming how many are pending
+
+### Requirement: Priority renders as a keycap digit
+The system SHALL render an issue's priority as the corresponding keycap emoji — `P0` as `0️⃣`,
+`P1` as `1️⃣`, `P2` as `2️⃣`, `P3` as `3️⃣` — rather than the literal label text. An issue with no
+priority label SHALL render a fixed-width blank in that position, so rows stay column-aligned.
+
+#### Scenario: A prioritized issue renders
+- **WHEN** a row for a `P1` issue is rendered
+- **THEN** its priority column shows `1️⃣` and not the text `P1`
+
+#### Scenario: An unprioritized issue renders alongside prioritized ones
+- **WHEN** rows for a `P1` issue and an issue with no priority label render in the same section
+- **THEN** both rows' subsequent columns remain aligned with each other
+
+### Requirement: Concurrent comment prefetch preserves existing note content
+The system SHALL fetch blocked/needs-attention issues' comment-derived notes concurrently (not
+serially) while preserving the exact note content each issue would have received under the
+previous serial implementation, and without changing the total number of `gh` calls made.
+
+#### Scenario: Blocked/needs-attention notes render unchanged
+- **WHEN** one or more issues carry the `blocked` or `needs-attention` label
+- **THEN** their comment-derived notes (`blocked_note`, `attention_note`) render with the same
+  content as before the change
+
+### Requirement: Per-row failure isolation during concurrent prefetch
+The system SHALL isolate failures in the concurrent comment prefetch so that one issue's failed
+`gh issue view --json comments` call (whether a process error or a malformed-JSON response)
+falls back to a fixed placeholder note for that issue alone, without aborting the batch or
+affecting any other issue's note.
+
+#### Scenario: One issue's comment fetch fails during the concurrent prefetch
+- **WHEN** `gh issue view ... --json comments` fails (process error or malformed JSON) for one
+  blocked/needs-attention issue during the concurrent prefetch
+- **THEN** that issue's row falls back to `"see issue comments"` exactly as today, and other
+  rows' notes are unaffected — no single failure aborts the batch
+
+### Requirement: `render_board()` is decomposed into one function per section
+The system SHALL structure `render_board()` as one function per rendered section, each returning
+its own lines, so that a section's conditional presence is decided in one place rather than
+inline within a single large function.
+
+#### Scenario: A section with no content contributes no lines
+- **WHEN** a per-section render function is called with no rows to render
+- **THEN** it returns no lines, and the assembled board contains no trace of that section
+
+### Requirement: Test suite covers the new render
+The system's test suite (`test-board.sh`) SHALL cover the summary-count rendering of backlog and
+epics, the absence of every empty section and zero count, the narrowed "next up" behavior
+including its silence when no ready work exists, the conditional archive suggestion, keycap
+priority rendering and column alignment, and the concurrent prefetch's transparency and
+failure-isolation behavior.
+
+#### Scenario: Test suite passes after the change
+- **WHEN** `plugins/spec-flow/scripts/test-board.sh` is run after this change
+- **THEN** it exits 0

--- a/openspec/changes/issue-46/tasks.md
+++ b/openspec/changes/issue-46/tasks.md
@@ -1,0 +1,92 @@
+## 1. Retained from the first implementation
+
+These landed under the original scope and survive the re-scope unchanged. Nothing to redo; listed
+so the change's task list matches what is actually on the branch.
+
+- [x] 1.1 Broaden `last_comment_matching()`'s exception handling to catch `json.JSONDecodeError`
+      alongside `subprocess.CalledProcessError`, returning `None` in both cases.
+- [x] 1.2 `prefetch_notes(issues)` — scan for `blocked`/`needs-attention` labels, submit one
+      `last_comment_matching()` call per (issue, note-kind) pair into a second
+      `ThreadPoolExecutor(max_workers=4)` block, return two `{issue_number: str | None}` dicts.
+- [x] 1.3 In `main()`, rebind `blocked_reason_fn`/`needs_attention_note_fn` to dict lookups
+      against `prefetch_notes()`'s results. `build_rows()` unchanged.
+- [x] 1.4 Decompose `render_board()` into one function per rendered section, reducing
+      `render_board()` itself to bucket computation plus ordered section calls.
+
+## 2. Remove the capping design
+
+- [x] 2.1 Delete `BACKLOG_DISPLAY_CAP`, `EPIC_SUBISSUE_DISPLAY_CAP` and the `capped()` helper.
+- [x] 2.2 Remove the `--full` flag from `argparse` and drop the `full` parameter from
+      `render_board()` and every section function that threads it.
+- [x] 2.3 Delete `test-board.sh`'s fixture 5 and every cap/`--full` assertion in fixtures 2, 3
+      and 4. Keep those fixtures' prefetch and failure-isolation assertions.
+
+## 3. Backlog and epics become counts
+
+- [x] 3.1 Replace `render_backlog()` and `render_epics()` with counts contributed to the summary
+      line. Neither renders a per-issue row.
+- [x] 3.2 Leave `ISSUE_LIMIT` and pagination alone — this change alters rendering, not how much
+      the board retrieves.
+- [x] 3.3 Drop `subIssues` from `fetch_issues()`'s `--json` field list, and the `sub_issues`,
+      `sub_total` and `sub_completed` row keys from `build_rows()`. Nothing reads them once epics
+      report as a count. Keep `subIssuesSummary` — `is_epic` reads its `total`.
+
+## 4. Conditional rendering
+
+- [x] 4.1 Make every section function return no lines when it has no content, so a section with
+      nothing to report leaves no header, no count and no blank line behind.
+- [x] 4.2 Rewrite the summary line to omit any count that is zero, rather than rendering
+      `blocked: 0`-style entries.
+- [x] 4.3 Move the archive suggestion out of the summary line into its own conditional line,
+      rendered only when specs are pending and naming how many.
+
+## 5. Narrow "next up"
+
+- [x] 5.1 Reduce `compute_next_up()` to the single ready-issue case: unclaimed `status:ready`,
+      sorted by `priority_key`, returning the top row or `None`.
+- [x] 5.2 Drop its `blocked_on_you` and `backlog` parameters and update the call site.
+- [x] 5.3 Delete the merge-a-green-PR rung, the unblock rung and its four action strings, and the
+      backlog-groom fallback.
+- [x] 5.4 Confirm `render_next_up()` emits nothing when `compute_next_up()` returns `None`.
+- [x] 5.5 Leave `blocked_on_you` bucketing and `render_blocked_on_you()` intact — the section
+      still renders, it just no longer feeds a recommendation.
+
+## 6. Keycap priority
+
+- [x] 6.1 Add a priority → keycap mapping (`P0` → `0️⃣` … `P3` → `3️⃣`) beside `PRIORITY_ORDER`.
+- [x] 6.2 Replace `render_row()`'s `{row['priority'] or '--':3}` with the keycap plus a literal
+      space. Do not use format-width padding: a keycap is three codepoints but renders in about
+      two cells, so `:3` misaligns every row.
+- [x] 6.3 Render a fixed-width blank for an issue with no priority label, matching the keycap's
+      display width so columns stay aligned.
+
+## 7. Tests
+
+- [x] 7.1 Assert the summary line reports an ungroomed count and that no ungroomed issue renders
+      as its own row.
+- [x] 7.2 Assert two renders differing only in backlog size produce the same number of lines.
+- [x] 7.3 Assert no empty section header, no zero count and no `specs pending archive: 0` text
+      appears when the corresponding content is absent.
+- [x] 7.4 Assert "next up" names the P0 issue when unclaimed ready issues exist at P0 and P2.
+- [x] 7.5 Assert no "next up" line renders when no unclaimed ready issue exists, including when
+      the backlog is non-empty.
+- [x] 7.6 Assert "next up" does not recommend merging a green in-review PR, across all three
+      liveness states (🟢 active, 🟡 claimed, 🔴 stalled).
+- [x] 7.7 Assert a `needs-attention` issue renders under BLOCKED ON YOU with its attach
+      instruction while "next up" does not name it.
+- [x] 7.8 Assert the archive suggestion renders with its count when specs are pending.
+- [x] 7.9 Assert a `P1` row's priority column shows `1️⃣` and not the text `P1`, and that a
+      prioritized and an unprioritized row in the same section stay column-aligned.
+- [x] 7.10 Confirm the retained prefetch transparency and failure-isolation assertions still pass
+      unchanged.
+- [x] 7.11 Run the full suite and confirm it exits 0. Run `shellcheck test-board.sh` and confirm
+      it is clean — `main`'s copy is, and this change must not regress it.
+
+## 8. Skill documentation
+
+- [x] 8.1 Update `skills/board/SKILL.md`'s bucket list — BACKLOG and EPICS no longer render as
+      sections.
+- [x] 8.2 Remove SKILL.md's judgment step. It was conditional on "next up" recommending a backlog
+      issue to groom, which no longer happens, leaving the step unreachable. Nothing replaces it:
+      the board now reports state and recommends only unowned ready work, both decided by the
+      script.

--- a/plugins/spec-flow/scripts/board.py
+++ b/plugins/spec-flow/scripts/board.py
@@ -5,10 +5,15 @@ Moves everything `board/SKILL.md` used to make the model do by hand — pulling 
 list`/`gh pr list` JSON into context, joining it against PR/CI state and local sessions, bucketing
 by lifecycle, computing "next up"/"blocked on you"/"stalled", and formatting the final board text —
 into one script. The model runs this and prints its stdout; it never sees the raw GitHub JSON and
-never hand-writes a join script. Stdlib only, shells out to `gh`/`git`/`claude`.
+never hand-writes a join script. `render_board()` is one function per rendered section, and every
+section renders only when it has something to report — no empty header, no zero count, no
+placeholder line. The two unbounded categories (the ungroomed backlog and the epic list) report as
+counts in the summary line rather than as rows, so the board's rendered length does not grow with
+the backlog. `prefetch_notes()` fetches blocked/needs-attention comment notes concurrently instead
+of one-by-one inside `build_rows()`. Stdlib only, shells out to `gh`/`git`/`claude`.
 
 THIS FILE IS THE AUTHORITY on the classification rules — what counts as "blocked on you",
-"stalled", "claimed", the "next up" ladder, epic exclusion and PR/CI correlation. Each rule is
+"stalled", "claimed", what "next up" recommends, epic exclusion and PR/CI correlation. Each rule is
 stated in a comment beside the code that implements it. skills/board/SKILL.md covers how to invoke
 this and what to do with the output; it deliberately does not restate the rules, so the two cannot
 drift apart.
@@ -35,6 +40,17 @@ STATUS_ORDER = ["spec-review", "in-review", "in-progress", "addressing", "ready"
 # opposite of what a stale-leftover tie-break is for.
 LIFECYCLE_ORDER = ["ready", "spec-review", "in-progress", "in-review", "addressing"]
 PRIORITY_ORDER = ["P0", "P1", "P2", "P3"]
+# Rendered instead of the literal label text. A keycap is three codepoints -- the digit, U+FE0F and
+# U+20E3 -- but a terminal draws it in about two cells, so format-width padding (`:3`) pads a
+# prioritized row differently from an unprioritized one and every column after it drifts. Emit the
+# keycap followed by a literal space instead, and PRIORITY_BLANK when there is no priority label:
+# all four keycaps are the same width, so the columns line up without measuring anything.
+PRIORITY_KEYCAP = {"P0": "0️⃣", "P1": "1️⃣", "P2": "2️⃣", "P3": "3️⃣"}
+PRIORITY_BLANK = "  "
+
+
+def keycap(priority):
+    return PRIORITY_KEYCAP.get(priority, PRIORITY_BLANK)
 
 
 def fail(message):
@@ -65,7 +81,7 @@ PR_LIMIT = 200
 
 def fetch_issues():
     return gh_json(["issue", "list", "--state", "open", "--json",
-                     "number,title,labels,url,assignees,subIssuesSummary,subIssues",
+                     "number,title,labels,url,assignees,subIssuesSummary",
                      "--limit", str(ISSUE_LIMIT)], default=[])
 
 
@@ -112,12 +128,34 @@ def fetch_archive_pending():
 
 
 def last_comment_matching(number, prefix=None):
+    args = ["issue", "view", str(number), "--json", "comments"]
     try:
-        comments = json.loads(run(["gh", "issue", "view", str(number), "--json", "comments"])).get("comments", [])
-    except subprocess.CalledProcessError:
+        comments = json.loads(run(["gh", *args])).get("comments", [])
+    except subprocess.CalledProcessError as e:
+        print(f"board: warning: 'gh {' '.join(args)}' failed, continuing without it: {e.stderr.strip()}", file=sys.stderr)
+        return None
+    except json.JSONDecodeError as e:
+        print(f"board: warning: 'gh {' '.join(args)}' returned malformed JSON, continuing without it: {e}", file=sys.stderr)
         return None
     candidates = [c.get("body", "") for c in comments if not prefix or c.get("body", "").startswith(prefix)]
     return candidates[-1] if candidates else None
+
+
+def prefetch_notes(issues):
+    blocked_numbers = [i["number"] for i in issues if "blocked" in label_names(i)]
+    attention_numbers = [i["number"] for i in issues if "needs-attention" in label_names(i)]
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        blocked_futures = {n: pool.submit(last_comment_matching, n, "⛔ Blocked on") for n in blocked_numbers}
+        # Must filter by prefix. Without one this returns the last comment of ANY kind, and
+        # the pipeline posts several after an attention request, so the row shows an
+        # unrelated line. issue-manager posts the request with this prefix; see
+        # agents/issue-manager.md.
+        attention_futures = {n: pool.submit(last_comment_matching, n, "🆘 Needs attention")
+                             for n in attention_numbers}
+    return (
+        {n: f.result() for n, f in blocked_futures.items()},
+        {n: f.result() for n, f in attention_futures.items()},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -222,9 +260,6 @@ def build_rows(issues, prs, me, sessions, blocked_reason_fn, needs_attention_not
             "assignee": assignee,
             "mine": me is not None and assignee == me,
             "is_epic": is_epic,
-            "sub_issues": issue.get("subIssues", {}).get("nodes", []) if is_epic else [],
-            "sub_total": (issue.get("subIssuesSummary") or {}).get("total", 0),
-            "sub_completed": (issue.get("subIssuesSummary") or {}).get("completed", 0),
             "agent_active": "agent:active" in labels,
             "blocked": "blocked" in labels,
             "needs_attention": "needs-attention" in labels,
@@ -284,7 +319,7 @@ def liveness_marker(row):
 
 
 def render_row(row):
-    bits = [f"{row['status'] or '(no status)':13} #{row['number']:<5} {row['priority'] or '--':3} {row['title']}"]
+    bits = [f"{row['status'] or '(no status)':13} #{row['number']:<5} {keycap(row['priority'])} {row['title']}"]
     bits.append(f"@{row['assignee']}" if row["assignee"] else "(unclaimed)")
     if row["pr_number"]:
         ci_marker = {"green": "✅ CI", "running": "⏳ CI", "failing": "❌ CI"}[row["ci"]]
@@ -301,13 +336,141 @@ def render_row(row):
     return "  " + "  ".join(b for b in bits if b)
 
 
+def render_blocked_on_you(blocked_on_you):
+    out = []
+    if blocked_on_you:
+        out.append("⛳ BLOCKED ON YOU")
+        for r in blocked_on_you:
+            out.append(render_row(r))
+        out.append("")
+    return out
+
+
+def render_unrecognized(unrecognized):
+    out = []
+    if unrecognized:
+        out.append("❓ UNRECOGNIZED STATUS (fix the label — these are in no pipeline stage)")
+        for r in unrecognized:
+            out.append(render_row(r))
+        out.append("")
+    return out
+
+
+def render_in_flight(in_flight):
+    out = []
+    if in_flight:
+        out.append("🔧 IN FLIGHT (agents / CI)")
+        for r in in_flight:
+            out.append(render_row(r))
+        out.append("")
+    return out
+
+
+def render_ready(ready_rows):
+    out = []
+    if ready_rows:
+        out.append("📋 READY")
+        for r in ready_rows:
+            out.append(render_row(r))
+        out.append("")
+    return out
+
+
+# --- Next up (never an epic) ---------------------------------------------------------------
+# (verb, row, action) — rendered as a header plus one `- <number>: <title> → <action>` line, so
+# the title is never wedged between two colons in a single sentence. See the convention in
+# docs/workflow.md.
+def compute_next_up(ready_rows):
+    # The ONE thing the board recommends: an unclaimed status:ready issue, highest priority first.
+    # It is the only work on the board with no owner at all. Merging a green PR, unblocking a
+    # stopped agent and grooming a backlog issue were each recommended here once, and each names
+    # work another agent already drives -- that issue's own issue-manager, or the backlog's. The
+    # board reports state; it does not direct work it does not drive. See design.md, D4.
+    unclaimed_ready = [r for r in ready_rows if r["assignee"] is None]
+    if not unclaimed_ready:
+        return None
+    unclaimed_ready.sort(key=lambda r: priority_key(r["priority"]))
+    top = unclaimed_ready[0]
+    return ("activate", top, f"/spec-flow:activate {top['number']}")
+
+
+def count_bit(n, singular, plural=None):
+    # A zero count renders nothing at all. `blocked: 0` makes the reader parse a number to learn
+    # that nothing happened; an absent entry reports the same thing by saying nothing.
+    if not n:
+        return None
+    return f"{n} {singular if n == 1 else (plural or singular + 's')}"
+
+
+def render_summary(non_epics, blocked_rows, backlog, epics):
+    # The ungroomed backlog and the epic list appear here and nowhere else. Both grow without
+    # bound -- the delivery buckets above are bounded by how many agents can run at once, these are
+    # bounded by nothing -- so they report as a number and the board's length stops tracking the
+    # size of the backlog. See design.md, D2.
+    summary_bits = [
+        count_bit(len(backlog), "ungroomed", "ungroomed"),
+        count_bit(len(epics), "epic"),
+        count_bit(sum(1 for r in non_epics if r["agent_active"]), "agent:active", "agent:active"),
+        count_bit(len(blocked_rows), "blocked", "blocked"),
+        count_bit(sum(1 for r in non_epics if r["needs_attention"]), "needs-attention", "needs-attention"),
+        count_bit(sum(1 for r in non_epics if r["attach_id"]), "local session matched", "local sessions matched"),
+        count_bit(sum(1 for r in non_epics if r["pr_number"]), "open PR"),
+    ]
+    summary_bits = [b for b in summary_bits if b]
+    if not summary_bits:
+        return []
+    return ["(" + " · ".join(summary_bits) + ")"]
+
+
+def render_archive_suggestion(archive_pending):
+    # Its own line rather than a summary entry, and only when something is actually pending: the
+    # absent line is the report. On screen there is something to archive; off screen there is not,
+    # with no `specs pending archive: 0` to read past either way.
+    if not archive_pending:
+        return []
+    noun = "spec" if archive_pending == 1 else "specs"
+    return ["", f"🗄️  {archive_pending} {noun} pending archive → /spec-flow:archive"]
+
+
+def render_next_up(next_up):
+    out = []
+    if next_up:
+        out.append("")
+        verb, row, action = next_up
+        out.append(f"➡️  Next up — {verb}:")
+        out.append(f"  - {describe(row)} → {action}")
+    return out
+
+
+# Convention: one issue per line, `- <number>: <title>` — never comma-joined inline.
+# See docs/workflow.md, "Conventions".
+def render_stalled(stalled):
+    out = []
+    if stalled:
+        out.append("")
+        out.append("🔴 Stalled (yours, no agent:active):")
+        for r in stalled:
+            out.append(f"  - {describe(r)} → {SPAWN_SCRIPT} {r['number']}")
+    return out
+
+
+def render_blocked(blocked_rows):
+    out = []
+    if blocked_rows:
+        out.append("")
+        out.append("🔒 Blocked:")
+        for r in blocked_rows:
+            out.append(f"  - {describe(r)} — {r['blocked_note']}")
+    return out
+
+
 def render_board(rows, me, archive_pending):
     epics = [r for r in rows if r["is_epic"]]
     non_epics = [r for r in rows if not r["is_epic"]]
+    # Counted, never rendered as rows -- so neither list needs sorting.
     backlog = [r for r in non_epics if r["status"] is None]
     staged = [r for r in non_epics if r["status"] is not None]
     staged.sort(key=lambda r: (priority_key(r["priority"]), r["number"]))
-    backlog.sort(key=lambda r: (priority_key(r["priority"]), r["number"]))
 
     def is_blocked_on_you(r):
         if not r["mine"]:
@@ -351,126 +514,33 @@ def render_board(rows, me, archive_pending):
                     if r["status"] not in STATUS_ORDER
                     and r not in blocked_on_you]
 
-    out = ["## Delivery board", ""]
-
-    if blocked_on_you:
-        out.append("⛳ BLOCKED ON YOU")
-        for r in blocked_on_you:
-            out.append(render_row(r))
-        out.append("")
-
-    if unrecognized:
-        out.append("❓ UNRECOGNIZED STATUS (fix the label — these are in no pipeline stage)")
-        for r in unrecognized:
-            out.append(render_row(r))
-        out.append("")
-
-    if in_flight:
-        out.append("🔧 IN FLIGHT (agents / CI)")
-        for r in in_flight:
-            out.append(render_row(r))
-        out.append("")
-
-    if ready_rows:
-        out.append("📋 READY")
-        for r in ready_rows:
-            out.append(render_row(r))
-        out.append("")
-
-    if backlog:
-        out.append("📥 BACKLOG (ungroomed)")
-        for r in backlog:
-            out.append(f"  (no labels)  #{r['number']:<5} {r['title']}  → /spec-flow:groom {r['number']}")
-        out.append("")
-
-    if epics:
-        out.append("📦 EPICS (not directly workable — see sub-issues)")
-        for r in epics:
-            out.append(f"  {r['status'] or '(no status)':13} #{r['number']:<5} {r['priority'] or '--':3} {r['title']}  "
-                        f"{r['sub_total']} sub-issues ({r['sub_completed']} done)")
-            # Convention: one issue per line, `- <number>: <title>` — never a comma-joined
-            # run of issues inline. See docs/workflow.md, "Conventions".
-            if r["sub_issues"]:
-                for s in r["sub_issues"]:
-                    out.append(f"      - {s.get('number')}: {s.get('title', '')}")
-            else:
-                out.append("      (no sub-issues listed)")
-        out.append("")
-
-    # --- Next up (scoped to `me`, never an epic) -------------------------------------------
-    # (verb, row, action) — rendered as a header plus one `- <number>: <title> → <action>` line,
-    # so the title is never wedged between two colons in a single sentence. See the convention in
-    # docs/workflow.md.
-    next_up = None
-    # Rung 0: anything already in the BLOCKED ON YOU bucket outranks starting or grooming work --
-    # it is the closest thing to landed, and the board contradicted itself by rendering an issue
-    # under "blocked on you" and then recommending the owner go groom something else.
-    mine_in_review_green = [r for r in staged if r["mine"] and r["status"] == "in-review" and r["ci"] == "green"]
-    other_blocked_on_you = [r for r in blocked_on_you if r not in mine_in_review_green]
-    if mine_in_review_green:
-        mine_in_review_green.sort(key=lambda r: priority_key(r["priority"]))
-        top = mine_in_review_green[0]
-        next_up = ("finish", top, f"PR #{top['pr_number']} is green, merge it")
-    elif other_blocked_on_you:
-        other_blocked_on_you.sort(key=lambda r: priority_key(r["priority"]))
-        top = other_blocked_on_you[0]
-        if top["needs_attention"]:
-            action = "an agent is stopped waiting on you — see the issue comments"
-        elif top["status"] == "spec-review":
-            action = "approve or redirect the spec (Seam 1)"
-        elif top["status"] == "ready":
-            action = "a session is parked on your design choice — attach to it"
-        else:
-            action = f"review PR #{top['pr_number']}" if top["pr_number"] else "review it"
-        next_up = ("unblock", top, action)
-    else:
-        unclaimed_ready = [r for r in ready_rows if r["assignee"] is None]
-        if unclaimed_ready:
-            unclaimed_ready.sort(key=lambda r: priority_key(r["priority"]))
-            top = unclaimed_ready[0]
-            next_up = ("activate", top, f"/spec-flow:activate {top['number']}")
-        elif backlog:
-            top = backlog[0]
-            next_up = ("groom", top, f"/spec-flow:groom {top['number']}")
-
     stalled = [r for r in staged if is_stalled(r)]
     blocked_rows = [r for r in non_epics if r["blocked"]]
+    next_up = compute_next_up(ready_rows)
 
-    summary_bits = [
-        f"agent:active: {sum(1 for r in non_epics if r['agent_active'])}",
-        f"blocked: {len(blocked_rows)}",
-        f"needs-attention: {sum(1 for r in non_epics if r['needs_attention'])}",
-        f"local sessions matched: {sum(1 for r in non_epics if r['attach_id'])}",
-        f"open PRs: {sum(1 for r in non_epics if r['pr_number'])}",
-    ]
-    if archive_pending:
-        summary_bits.append(f"specs pending archive: {archive_pending} → /spec-flow:archive")
-    out.append("(" + " · ".join(summary_bits) + ")")
+    out = ["## Delivery board", ""]
+    out += render_blocked_on_you(blocked_on_you)
+    out += render_unrecognized(unrecognized)
+    out += render_in_flight(in_flight)
+    out += render_ready(ready_rows)
+    out += render_summary(non_epics, blocked_rows, backlog, epics)
+    out += render_archive_suggestion(archive_pending)
+    out += render_next_up(next_up)
+    out += render_stalled(stalled)
+    out += render_blocked(blocked_rows)
 
-    if next_up:
-        out.append("")
-        verb, row, action = next_up
-        out.append(f"➡️  Next up — {verb}:")
-        out.append(f"  - {describe(row)} → {action}")
-    # Convention: one issue per line, `- <number>: <title>` — never comma-joined inline.
-    # See docs/workflow.md, "Conventions".
-    if stalled:
-        out.append("")
-        out.append("🔴 Stalled (yours, no agent:active):")
-        for r in stalled:
-            out.append(f"  - {describe(r)} → {SPAWN_SCRIPT} {r['number']}")
-    if blocked_rows:
-        out.append("")
-        out.append("🔒 Blocked:")
-        for r in blocked_rows:
-            out.append(f"  - {describe(r)} — {r['blocked_note']}")
+    # Each row section appends a trailing "" to separate itself from the next one. Whichever
+    # section happens to be last has nothing to separate itself from, so drop that separator --
+    # otherwise removing sections leaves the board padded with the gaps they used to fill.
+    while out and not out[-1]:
+        out.pop()
 
     return "\n".join(out)
 
 
 def main():
     parser = argparse.ArgumentParser(description="Render the spec-flow delivery board deterministically.")
-    parser.add_argument("--user", help="scope 'next up'/'blocked on you' to this login (default: gh's authenticated user)")
+    parser.add_argument("--user", help="scope 'blocked on you' to this login (default: gh's authenticated user)")
     args = parser.parse_args()
 
     for binary in ("gh", "git"):
@@ -491,18 +561,17 @@ def main():
         print("board: warning: couldn't resolve the authenticated user ('gh api user' failed) — "
               "'mine'/'blocked on you' scoping will show nothing as yours", file=sys.stderr)
 
+    blocked_bodies, attention_bodies = prefetch_notes(issues)
+
     def blocked_reason_fn(n):
-        body = last_comment_matching(n, prefix="⛔ Blocked on")
+        body = blocked_bodies.get(n)
         if not body:
             return None
         m = re.match(r"^(⛔ Blocked on #\d+[^\n]*)", body)
         return m.group(1) if m else body.splitlines()[0]
 
     def needs_attention_note_fn(n):
-        # Must filter by prefix. Without one this returns the last comment of ANY kind, and the
-        # pipeline posts several after an attention request, so the row shows an unrelated line.
-        # issue-manager posts the request with this prefix; see agents/issue-manager.md.
-        body = last_comment_matching(n, prefix="🆘 Needs attention")
+        body = attention_bodies.get(n)
         return body.splitlines()[0] if body else None
 
     rows = build_rows(issues, prs, me, sessions, blocked_reason_fn, needs_attention_note_fn)

--- a/plugins/spec-flow/scripts/test-board.sh
+++ b/plugins/spec-flow/scripts/test-board.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # Structural + behavioral test for board.py. Fakes `gh`/`git`/`claude` on PATH so this runs
 # offline, deterministically, and exercises the branches this repo's own real board data
-# doesn't (epics, PR/CI correlation, blocked/needs-attention reasons, stalled detection, the
-# "next up" ladder) rather than relying on live GitHub state. Exits non-zero if any assertion
+# doesn't (epics, PR/CI correlation, blocked/needs-attention reasons, stalled detection,
+# "next up") rather than relying on live GitHub state. Exits non-zero if any assertion
 # fails. macOS bash 3.2 compatible (no associative arrays, no mapfile).
+#
+# Four fixtures, each with a job:
+#   1  the broad behavioral fixture -- every bucket, PR/CI correlation, liveness, notes
+#   2  the concurrent comment prefetch and its per-row failure isolation
+#   3  nothing to report -- the conditional-rendering fixture (no section, no zero count)
+#   4  "next up" priority ordering and its refusal to name a claimed issue
+# Plus in-process python blocks for the cases a PATH fixture can't reach cheaply: the three
+# liveness states of one green in-review PR, backlog-size line invariance, and keycap alignment.
 set -uo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
@@ -27,14 +35,17 @@ check() {
 command -v python3 >/dev/null 2>&1 || { echo "test-board: 'python3' is required but not on PATH." >&2; exit 1; }
 
 fake_bin_dir="$(mktemp -d)"
-trap 'rm -rf "$fake_bin_dir"' EXIT
+fake_bin_dir2="$(mktemp -d)"
+fake_bin_dir3="$(mktemp -d)"
+fake_bin_dir4="$(mktemp -d)"
+trap 'rm -rf "$fake_bin_dir" "$fake_bin_dir2" "$fake_bin_dir3" "$fake_bin_dir4"' EXIT
 
 # ---------------------------------------------------------------------------
-# Fixture: 8 issues covering every branch --
+# Fixture 1: 12 issues covering every branch --
 #   #10 status:spec-review, mine                  -> BLOCKED ON YOU
-#   #11 status:in-review, mine, PR #90 CI green    -> BLOCKED ON YOU + next-up candidate
+#   #11 status:in-review, mine, PR #90 CI green    -> BLOCKED ON YOU (never a merge suggestion)
 #   #12 status:in-progress, mine, NO agent:active  -> STALLED
-#   #13 status:ready, unclaimed, P0                -> READY, next-up candidate if #11 didn't win
+#   #13 status:ready, unclaimed, P0                -> READY, and the "next up" pick
 #   #14 status:ready, claimed by alice              -> READY, not "yours"
 #   #15 blocked label, mine                         -> BLOCKED (reason from last matching comment)
 #   #16 needs-attention label, mine                 -> BLOCKED ON YOU (reason from 🆘-prefixed comment)
@@ -45,8 +56,8 @@ trap 'rm -rf "$fake_bin_dir"' EXIT
 #   #18 status:ready, mine, agent:active             -> BLOCKED ON YOU (activate's design stop --
 #                                                        holds status:ready the whole wait)
 #   #19 status:in-review, mine, NO linked PR (ci None) -> BLOCKED ON YOU, not "waiting on CI"
-#   #20 epic (subIssuesSummary.total=2)              -> EPICS, excluded from every other bucket
-#   #30 no status label                              -> BACKLOG
+#   #20 epic (subIssuesSummary.total=2)              -> counted as "1 epic", rendered as no row
+#   #30 no status label                              -> counted as "1 ungroomed", no row
 # ---------------------------------------------------------------------------
 cat > "$fake_bin_dir/gh" <<'GHEOF'
 #!/usr/bin/env bash
@@ -141,20 +152,8 @@ check "a session under the PRE-RENAME issue-pm- prefix still matches its issue (
 echo "$out" | grep -q "#12 .*STALLED"
 check "in-progress issue with no agent:active is marked STALLED" $?
 
-echo "$out" | grep -qE "^  \(no labels\)  #30"
-check "issue with no status label lands in BACKLOG" $?
-
 ! echo "$out" | grep -q "#20 .*BLOCKED ON YOU\|#20 .*READY"
-check "epic never appears in READY/BLOCKED ON YOU (only in its own EPICS section)" $?
-
-# `check` only sees the LAST command's status, so every condition must be one expression.
-echo "$out" | grep -q "EPICS" \
-  && echo "$out" | grep -q "^      - 21: Sub one$" \
-  && echo "$out" | grep -q "^      - 22: Sub two$"
-check "epic lists its sub-issues one per line, as '- <number>: <title>'" $?
-
-! echo "$out" | grep -q "Sub one), #22"
-check "epic sub-issues are never comma-joined inline" $?
+check "epic never appears in READY/BLOCKED ON YOU" $?
 
 echo "$out" | sed -n '/🔒 Blocked:/,$p' | grep -q "^  - 15: Blocked item — ⛔ Blocked on #99 — waiting on infra work.$"
 check "blocked reason comes from the matching ⛔-prefixed comment, not just 'see issue comments'" $?
@@ -168,7 +167,27 @@ check "needs-attention note comes from the matching 🆘-prefixed comment, not a
 echo "$out" | grep -q "#16 .*🟡 claimed — agent:active set, no session on this machine"
 check "an agent:active label with no local session renders claimed, neither active nor stalled" $?
 
-# --- issue 58: work blocked on the owner must be visible and must outrank starting new work ---
+# --- Unbounded categories report as counts, never as rows (spec: counts, not rows) ---
+
+# The exact summary line, not a substring: this asserts BOTH that the two unbounded categories are
+# counted and that every other count is still reported, in one place that a new fixture row breaks
+# loudly rather than silently.
+echo "$out" | grep -qxF "(1 ungroomed · 1 epic · 5 agent:active · 1 blocked · 1 needs-attention · 2 local sessions matched · 1 open PR)"
+check "the summary line reports every non-zero count, including ungroomed and epics" $?
+
+! echo "$out" | grep -q "#30"
+check "the ungroomed backlog issue is counted, never rendered as its own row" $?
+
+! echo "$out" | grep -q "BACKLOG"
+check "no BACKLOG section is rendered at all" $?
+
+! echo "$out" | grep -q "#20"
+check "the epic is counted, never rendered as its own row" $?
+
+! echo "$out" | grep -q "EPICS\|Sub one\|Sub two"
+check "no EPICS section and no epic sub-issue rows are rendered" $?
+
+# --- issue 58: work blocked on the owner must be visible ---
 
 # #18 is parked at activate's design-choice stop. It holds status:ready throughout that wait, so a
 # status-only rule renders it as an untouched backlog item and the owner never learns a session is
@@ -207,17 +226,66 @@ check "an issue shown under BLOCKED ON YOU is not rendered again under READY" $?
 blocked_section | grep -q "#19"
 check "status:in-review with no linked PR is blocked on you, not 'waiting on CI'" $?
 
-# "Next up" must draw from the board's own top bucket. Previously the ladder went straight from
-# mine+in-review+green to unclaimed-ready, so it told the owner to go groom while a spec sat
-# waiting for their approval.
-# Whatever it picks must come from the top bucket while that bucket is non-empty -- never a
-# "groom" or "activate" recommendation, which is what the old ladder produced by skipping it.
-echo "$out" | grep -qE "Next up — (finish|unblock):"
-check "'next up' draws from BLOCKED ON YOU while that bucket is non-empty, never groom/activate" $?
+# --- "Next up" names only unclaimed ready work ---
 
-# The fixture always has #11 (mine + in-review + green), so the "finish" rung always wins and the
-# new "unblock" rung never executes through the fixture. Exercise the ladder directly instead,
-# with no green in-review row present, so a regression that drops the rung is actually caught.
+# #11 is mine, in-review, with a green PR and a live session. That used to be the top "next up"
+# rung ("PR #90 is green, merge it"). It names work #11's own issue-manager already drives, so the
+# board reports the row and recommends the one issue nobody owns instead.
+echo "$out" | grep -qx "➡️  Next up — activate:"
+check "'next up' recommends activating unclaimed ready work" $?
+
+echo "$out" | sed -n '/Next up — activate:/,$p' | grep -q "^  - 13: Ready unclaimed → /spec-flow:activate 13$"
+check "'next up' names the highest-priority unclaimed ready issue (#13, P0)" $?
+
+! echo "$out" | grep -q "merge it"
+check "'next up' never recommends merging a green in-review PR" $?
+
+! echo "$out" | grep -qE "Next up — (finish|unblock|groom):"
+check "the finish/unblock/groom rungs are gone entirely" $?
+
+! echo "$out" | sed -n '/Next up — activate:/,$p' | grep -q "^  - 16:"
+check "a needs-attention issue is reported under BLOCKED ON YOU but never named by 'next up'" $?
+
+blocked_section | grep -q "#16"
+check "the same needs-attention issue does render its own BLOCKED ON YOU row" $?
+
+# --- the rest of fixture 1's coverage ---
+
+echo "$out" | grep -qx "🗄️  2 specs pending archive → /spec-flow:archive"
+check "the archive suggestion is its own line, names the count, and excludes the 'archive' entry" $?
+
+! echo "$out" | grep -q "specs pending archive:"
+check "the archive suggestion is no longer wedged into the summary line" $?
+
+echo "$out" | grep -q "#17 .*@alice"
+check "another user's spec-review issue is still shown (not silently dropped)" $?
+
+! blocked_section | grep -q "#17"
+check "another user's spec-review issue is NOT counted as blocked on you" $?
+
+section "🔧 IN FLIGHT" | grep -q "#17"
+check "another user's spec-review issue shows under IN FLIGHT for visibility" $?
+
+echo "$out" | sed -n '/Stalled (yours, no agent:active):/,$p' | grep -q "^  - 10: Spec review item →"
+check "the stalled SUMMARY line includes a stalled spec-review item too, consistent with its inline 🔴 STALLED marker" $?
+
+! echo "$out" | grep -q '{spawn}'
+check "the stalled summary's spawn command is a real path, not a leftover {spawn} placeholder" $?
+
+echo "$out" | grep -q "spawn-issue-manager.sh 10"
+check "the stalled summary's spawn command resolves to the real script next to board.py" $?
+
+# --- Keycap priority (spec: P0-P3 render as 0️⃣-3️⃣, unprioritized rows stay aligned) ---
+
+echo "$out" | grep -q "#13    0️⃣ Ready unclaimed"
+check "a P0 row's priority column renders the keycap, not the text 'P0'" $?
+
+! echo "$out" | grep -qE "#1[0-9] +P[0-3] "
+check "no row renders a literal P0/P1/P2/P3 in its priority column" $?
+
+# ---------------------------------------------------------------------------
+# In-process render tests: the cases a PATH fixture can't reach cheaply.
+# ---------------------------------------------------------------------------
 python3 - "$script_dir" <<'PYEOF'
 import sys, importlib.util, pathlib
 spec = importlib.util.spec_from_file_location("board", pathlib.Path(sys.argv[1]) / "board.py")
@@ -229,24 +297,111 @@ def row(**kw):
                 blocked=False, needs_attention=False, ci=None, pr_number=None, attach_id=None)
     base.update(kw); return base
 
-# A spec awaiting approval, plus an unclaimed ready item. Nothing green and in-review.
-rows = [row(number=10, status="spec-review"), row(number=30, status="ready", assignee=None, mine=False)]
-rendered = board.render_board(rows, "me", 0)
-out = rendered if isinstance(rendered, str) else "\n".join(rendered)
-assert "Next up — unblock:" in out, "expected the unblock rung to win; got:\n" + out
-assert "#10" in out or "10:" in out, "expected issue 10 to be recommended; got:\n" + out
+def next_up_lines(rendered):
+    lines = rendered.splitlines()
+    hits = [i for i, l in enumerate(lines) if l.startswith("➡️  Next up")]
+    if not hits:
+        return []
+    assert len(hits) == 1, f"more than one 'next up' header:\n{rendered}"
+    return lines[hits[0]:hits[0] + 2]
 
-# CI state mapping (issue 58 defect 4): queued/gated states are pending, never failing.
-for st in ("PENDING", "WAITING", "REQUESTED", "EXPECTED"):
-    got = board.ci_status([{"state": st}])
-    assert got == "running", f"{st} -> {got}, expected running"
-assert board.ci_status([{"status": "COMPLETED", "conclusion": None}]) == "running", "unknown conclusion must be pending"
-assert board.ci_status([{"state": "SUCCESS"}]) == "green"
-assert board.ci_status([{"conclusion": "FAILURE"}]) == "failing"
+# A green in-review PR is owned by that issue's own issue-manager whatever its liveness, so none of
+# the three states may produce a merge recommendation, and none may displace the unclaimed ready
+# item. The liveness marker is asserted too, so a state that stops being reachable fails loudly
+# instead of passing vacuously.
+for agent_active, attach_id, marker in ((True, "sess-1", "🟢 active"),
+                                        (True, None, "🟡 claimed"),
+                                        (False, None, "🔴 STALLED")):
+    rows = [row(number=11, status="in-review", ci="green", pr_number=90,
+                agent_active=agent_active, attach_id=attach_id),
+            row(number=13, title="Ready unclaimed", status="ready", priority="P0",
+                assignee=None, mine=False)]
+    out = board.render_board(rows, "me", 0)
+    assert marker in out, f"expected the {marker} state to be reachable; got:\n{out}"
+    assert "merge" not in out, f"{marker}: recommended a merge; got:\n{out}"
+    assert next_up_lines(out) == ["➡️  Next up — activate:",
+                                  "  - 13: Ready unclaimed → /spec-flow:activate 13"], \
+        f"{marker}: wrong 'next up'; got:\n{out}"
 PYEOF
-check "'next up' unblock rung fires with no green in-review item, and CI states map correctly" $?
+check "'next up' never recommends merging a green in-review PR, in any of the three liveness states" $?
 
-# Separate block so a failure below reports under its own name, not the ladder/CI check's.
+python3 - "$script_dir" <<'PYEOF'
+import sys, importlib.util, pathlib
+spec = importlib.util.spec_from_file_location("board", pathlib.Path(sys.argv[1]) / "board.py")
+board = importlib.util.module_from_spec(spec); spec.loader.exec_module(board)
+
+def row(**kw):
+    base = dict(number=1, title="t", url="u", status=None, priority="P1", assignee="me", mine=True,
+                is_epic=False, sub_issues=[], sub_total=0, sub_completed=0, agent_active=False,
+                blocked=False, needs_attention=False, ci=None, pr_number=None, attach_id=None)
+    base.update(kw); return base
+
+# The property the caps could only approximate: the board's rendered length does not vary with the
+# size of the backlog. Same state twice, differing only in how many ungroomed issues exist.
+def render(n_backlog):
+    rows = [row(number=10, status="spec-review"),
+            row(number=13, status="ready", priority="P0", assignee=None, mine=False)]
+    rows += [row(number=1000 + i, status=None, mine=False, assignee=None) for i in range(n_backlog)]
+    return board.render_board(rows, "me", 3)
+
+small, large = render(1), render(500)
+assert len(small.splitlines()) == len(large.splitlines()), \
+    f"backlog size changed the board's length: {len(small.splitlines())} vs {len(large.splitlines())}"
+# ...because the size is reported, not because it is ignored.
+assert "1 ungroomed" in small and "500 ungroomed" in large, f"backlog count not reported:\n{large}"
+
+# A needs-attention issue reports its row, with its attach instruction, and is still not the thing
+# "next up" names.
+rows = [row(number=16, title="Needs attention item", status="in-progress", needs_attention=True,
+            attention_note="🆘 Needs attention: owner input needed", agent_active=True,
+            attach_id="sess-xyz"),
+        row(number=13, title="Ready unclaimed", status="ready", priority="P0",
+            assignee=None, mine=False)]
+out = board.render_board(rows, "me", 0)
+lines = out.splitlines()
+start = lines.index("⛳ BLOCKED ON YOU")
+blocked = lines[start + 1:lines.index("", start)]
+assert any("#16" in l and "attach: claude agents — select sess-xyz" in l for l in blocked), \
+    f"needs-attention row missing from BLOCKED ON YOU, or missing its attach instruction:\n{out}"
+assert "  - 13: Ready unclaimed → /spec-flow:activate 13" in lines, f"wrong 'next up':\n{out}"
+assert not any(l.startswith("  - 16:") for l in lines), f"'next up' named the owned issue:\n{out}"
+PYEOF
+check "backlog size does not change the board's length, and BLOCKED ON YOU reports without recommending" $?
+
+python3 - "$script_dir" <<'PYEOF'
+import sys, importlib.util, pathlib
+spec = importlib.util.spec_from_file_location("board", pathlib.Path(sys.argv[1]) / "board.py")
+board = importlib.util.module_from_spec(spec); spec.loader.exec_module(board)
+
+def row(**kw):
+    base = dict(number=1, title="t", url="u", status=None, priority="P1", assignee="me", mine=True,
+                is_epic=False, sub_issues=[], sub_total=0, sub_completed=0, agent_active=False,
+                blocked=False, needs_attention=False, ci=None, pr_number=None, attach_id=None)
+    base.update(kw); return base
+
+assert [board.keycap(p) for p in ("P0", "P1", "P2", "P3")] == ["0️⃣", "1️⃣", "2️⃣", "3️⃣"]
+assert board.keycap(None) == board.keycap("P9") == "  ", "an unknown priority must render the blank"
+
+# A keycap is three codepoints -- digit, U+FE0F, U+20E3 -- but a terminal draws it in two cells,
+# so len() proves nothing about alignment. Substitute each keycap for the two spaces it occupies
+# and measure what is left. That is exactly the equivalence PRIORITY_BLANK relies on.
+def cells(s):
+    for kc in board.PRIORITY_KEYCAP.values():
+        s = s.replace(kc, "  ")
+    return len(s)
+
+rows = [row(number=13, title="AAA", status="ready", priority="P1", assignee=None, mine=False),
+        row(number=14, title="BBB", status="ready", priority=None, assignee=None, mine=False)]
+out = board.render_board(rows, "me", 0)
+line_a = next(l for l in out.splitlines() if "AAA" in l)
+line_b = next(l for l in out.splitlines() if "BBB" in l)
+assert "1️⃣" in line_a and "P1" not in line_a, f"P1 did not render as a keycap:\n{line_a}"
+assert cells(line_a[:line_a.index("AAA")]) == cells(line_b[:line_b.index("BBB")]), \
+    f"prioritized and unprioritized rows misalign:\n{line_a}\n{line_b}"
+PYEOF
+check "priority renders as a keycap, and a prioritized row stays aligned with an unprioritized one" $?
+
+# Separate block so a failure below reports under its own name, not the render checks'.
 python3 - "$script_dir" <<'PYEOF'
 import sys, importlib.util, pathlib
 spec = importlib.util.spec_from_file_location("board", pathlib.Path(sys.argv[1]) / "board.py")
@@ -260,8 +415,15 @@ def row(**kw):
 
 # An unknown status: label must land in a visible bucket, not vanish from the board entirely.
 out2 = board.render_board([row(number=99, status="in-progres", mine=False, assignee="alice")], "me", 0)
-out2 = out2 if isinstance(out2, str) else "\n".join(out2)
 assert "99" in out2, "an unrecognized status: label vanished from the board:\n" + out2
+
+# CI state mapping (issue 58 defect 4): queued/gated states are pending, never failing.
+for st in ("PENDING", "WAITING", "REQUESTED", "EXPECTED"):
+    got = board.ci_status([{"state": st}])
+    assert got == "running", f"{st} -> {got}, expected running"
+assert board.ci_status([{"status": "COMPLETED", "conclusion": None}]) == "running", "unknown conclusion must be pending"
+assert board.ci_status([{"state": "SUCCESS"}]) == "green"
+assert board.ci_status([{"conclusion": "FAILURE"}]) == "failing"
 
 # gh can emit an explicit JSON null; .get(default) returns the null and the old code raised on it,
 # taking down the whole render.
@@ -296,32 +458,313 @@ for seed in ("0", "1", "7", "42", "1234", "99999"):
                             capture_output=True, text=True, env=env, check=True).stdout.strip())
 assert seen == {expected}, f"status_of/priority_of wrong or hash-seed dependent: {seen} != {{{expected!r}}}"
 PYEOF
-check "unknown status label is rendered, null labels don't crash, label resolution is deterministic and lifecycle-ordered" $?
+check "unknown status label is rendered, CI states map correctly, null labels don't crash, label resolution is deterministic and lifecycle-ordered" $?
 
-echo "$out" | grep -q "specs pending archive: 2 → /spec-flow:archive"
-check "archive-pending count excludes the 'archive' entry itself" $?
+# ---------------------------------------------------------------------------
+# Fixture 2: the concurrent-prefetch fixture. Eleven ungroomed issues and an
+# epic with six sub-issues, both of which now report as counts -- kept at those
+# sizes so a regression that reintroduces per-issue rows is unmistakable. Five
+# blocked/needs-attention issues exercise the prefetch: a normal success (#401),
+# a `gh issue view` process failure (#402), a malformed-JSON response (#405), a
+# dual-labeled issue needing two independent calls (#404), and a plain
+# needs-attention success (#403).
+# ---------------------------------------------------------------------------
+cat > "$fake_bin_dir2/gh" <<'GHEOF'
+#!/usr/bin/env bash
+log_dir="$(cd "$(dirname "$0")" && pwd)"
+case "$1 $2" in
+  "issue list")
+    cat <<'JSON'
+[
+  {"number":201,"title":"Backlog 201","labels":[],"url":"https://x/201","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":202,"title":"Backlog 202","labels":[],"url":"https://x/202","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":203,"title":"Backlog 203","labels":[],"url":"https://x/203","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":204,"title":"Backlog 204","labels":[],"url":"https://x/204","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":205,"title":"Backlog 205 top priority","labels":[{"name":"P0"}],"url":"https://x/205","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":206,"title":"Backlog 206","labels":[],"url":"https://x/206","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":207,"title":"Backlog 207","labels":[],"url":"https://x/207","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":208,"title":"Backlog 208","labels":[],"url":"https://x/208","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":209,"title":"Backlog 209","labels":[],"url":"https://x/209","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":210,"title":"Backlog 210","labels":[],"url":"https://x/210","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":211,"title":"Backlog 211","labels":[],"url":"https://x/211","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":300,"title":"Big epic","labels":[{"name":"status:ready"},{"name":"P1"}],"url":"https://x/300","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":6},"subIssues":{"nodes":[{"number":301,"title":"Sub 301"},{"number":302,"title":"Sub 302"},{"number":303,"title":"Sub 303"},{"number":304,"title":"Sub 304"},{"number":305,"title":"Sub 305"},{"number":306,"title":"Sub 306"}]}},
+  {"number":401,"title":"Blocked ok","labels":[{"name":"status:in-progress"},{"name":"blocked"}],"url":"https://x/401","assignees":[{"login":"me"}],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":402,"title":"Blocked process failure","labels":[{"name":"status:in-progress"},{"name":"blocked"}],"url":"https://x/402","assignees":[{"login":"me"}],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":403,"title":"Attention ok","labels":[{"name":"status:in-progress"},{"name":"needs-attention"}],"url":"https://x/403","assignees":[{"login":"me"}],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":404,"title":"Dual label","labels":[{"name":"status:in-progress"},{"name":"blocked"},{"name":"needs-attention"}],"url":"https://x/404","assignees":[{"login":"me"}],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":405,"title":"Blocked malformed json","labels":[{"name":"status:in-progress"},{"name":"blocked"}],"url":"https://x/405","assignees":[{"login":"me"}],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}}
+]
+JSON
+    ;;
+  "pr list")
+    echo "[]"
+    ;;
+  "api user")
+    echo "me"
+    ;;
+  "repo view")
+    echo "main"
+    ;;
+  "issue view")
+    echo "$3" >> "$log_dir/issue_view_calls.log"
+    case "$3" in
+      401) echo '{"comments":[{"body":"note"},{"body":"⛔ Blocked on #77 — waiting on review."}]}' ;;
+      402) exit 1 ;;
+      403) echo '{"comments":[{"body":"first"},{"body":"🆘 Needs attention: needs input on design choice."}]}' ;;
+      404) echo '{"comments":[{"body":"first"},{"body":"⛔ Blocked on #88 — waiting on data."}]}' ;;
+      405) echo 'not valid json{' ;;
+      *) echo '{"comments":[]}' ;;
+    esac
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+GHEOF
+chmod +x "$fake_bin_dir2/gh"
 
-echo "$out" | grep -q "#17 .*@alice"
-check "another user's spec-review issue is still shown (not silently dropped)" $?
+cat > "$fake_bin_dir2/git" <<'GITEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "ls-tree" ]]; then
+  printf 'archive\n'
+  exit 0
+fi
+exit 1
+GITEOF
+chmod +x "$fake_bin_dir2/git"
 
-! echo "$out" | sed -n '/BLOCKED ON YOU/,/^$/p' | grep -q "#17"
-check "another user's spec-review issue is NOT counted as blocked on you" $?
+cat > "$fake_bin_dir2/claude" <<'CLAUDEEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "agents" ]]; then
+  echo '[]'
+  exit 0
+fi
+exit 1
+CLAUDEEOF
+chmod +x "$fake_bin_dir2/claude"
 
-echo "$out" | sed -n '/IN FLIGHT/,/^$/p' | grep -q "#17"
-check "another user's spec-review issue shows under IN FLIGHT for visibility" $?
+err2_log="$fake_bin_dir2/stderr.log"
+out2="$(PATH="$fake_bin_dir2:$PATH" python3 "$board" 2>"$err2_log")"
+status2=$?
+check "fixture 2: board.py exits 0" "$status2"
 
-echo "$out" | sed -n '/Stalled (yours, no agent:active):/,$p' | grep -q "^  - 10: Spec review item →"
-check "the stalled SUMMARY line includes a stalled spec-review item too, consistent with its inline 🔴 STALLED marker" $?
+echo "$out2" | grep -qxF "(11 ungroomed · 1 epic · 4 blocked · 2 needs-attention)"
+check "the summary counts eleven ungroomed and one epic, and omits every zero count" $?
 
-! echo "$out" | grep -q '{spawn}'
-check "the stalled summary's spawn command is a real path, not a leftover {spawn} placeholder" $?
+! echo "$out2" | grep -qE "#(20[1-9]|21[01]) "
+check "none of the eleven ungroomed issues renders a row" $?
 
-echo "$out" | grep -q "spawn-issue-manager.sh 10"
-check "the stalled summary's spawn command resolves to the real script next to board.py" $?
+! echo "$out2" | grep -q "Sub 30"
+check "none of the epic's six sub-issues renders a row" $?
 
-echo "$out" | grep -q "^➡️  Next up — finish:$" \
-  && echo "$out" | sed -n '/Next up — finish:/,$p' | grep -q "^  - 11: .* → PR #90 is green, merge it$"
-check "'next up' picks the mine+in-review+green-CI item over a ready/unclaimed one" $?
+! echo "$out2" | grep -q "Next up"
+check "'next up' renders nothing when no unclaimed ready issue exists, even with a full backlog" $?
+
+! echo "$out2" | grep -q "pending archive"
+check "no archive line renders when nothing is pending archive" $?
+
+echo "$out2" | grep -q "401.*BLOCKED on ⛔ Blocked on #77 — waiting on review."
+check "prefetch: a successful blocked-note fetch renders normally, attached to its own row" $?
+
+echo "$out2" | grep -q "402.*see issue comments"
+check "prefetch: a failed gh issue view (process error) falls back to 'see issue comments'" $?
+
+echo "$out2" | grep -q "405.*see issue comments"
+check "prefetch: a malformed-JSON gh issue view response falls back to 'see issue comments'" $?
+
+grep -q "^board: warning:.*402" "$err2_log"
+check "prefetch: a stderr warning is printed for the process-error fetch (issue #402)" $?
+
+grep -q "^board: warning:.*405" "$err2_log"
+check "prefetch: a stderr warning is printed for the malformed-JSON fetch (issue #405)" $?
+
+! grep -q "^board: warning:.*401" "$err2_log"
+check "prefetch: no stderr warning is printed for the successful fetch (issue #401)" $?
+
+echo "$out2" | grep -q "403.*NEEDS ATTENTION — 🆘 Needs attention: needs input on design choice."
+check "prefetch: a successful needs-attention fetch renders normally, attached to its own row" $?
+
+echo "$out2" | grep -q "404.*BLOCKED on ⛔ Blocked on #88 — waiting on data."
+check "prefetch: a dual-labeled (blocked + needs-attention) issue's blocked note renders" $?
+
+echo "$out2" | grep -q "404.*NEEDS ATTENTION"
+check "prefetch: the same dual-labeled issue's needs-attention note also renders" $?
+
+calls_402=$(grep -c '^402$' "$fake_bin_dir2/issue_view_calls.log")
+if [[ "$calls_402" -eq 1 ]]; then status_calls_402=0; else status_calls_402=1; fi
+check "prefetch: issue #402 was fetched exactly once, not retried after its failure" $status_calls_402
+
+calls_404=$(grep -c '^404$' "$fake_bin_dir2/issue_view_calls.log")
+if [[ "$calls_404" -eq 2 ]]; then status_calls_404=0; else status_calls_404=1; fi
+check "prefetch: the dual-labeled issue got two independent gh calls (blocked + needs-attention)" $status_calls_404
+
+total_calls=$(wc -l < "$fake_bin_dir2/issue_view_calls.log")
+if [[ "$total_calls" -eq 6 ]]; then status_total_calls=0; else status_total_calls=1; fi
+check "prefetch: total gh issue-view calls match the (issue, note-kind) pair count exactly" $status_total_calls
+
+# ---------------------------------------------------------------------------
+# Fixture 3: nothing to report. Three ungroomed issues and one epic -- both
+# count-only categories -- and no delivery work at all, so every section, the
+# archive line and "next up" must be absent, leaving three lines of board.
+# ---------------------------------------------------------------------------
+cat > "$fake_bin_dir3/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue list")
+    cat <<'JSON'
+[
+  {"number":501,"title":"Backlog 501","labels":[],"url":"https://x/501","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":502,"title":"Backlog 502","labels":[],"url":"https://x/502","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":503,"title":"Backlog 503","labels":[],"url":"https://x/503","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":600,"title":"Small epic","labels":[{"name":"status:ready"},{"name":"P1"}],"url":"https://x/600","assignees":[],"subIssuesSummary":{"completed":1,"percentCompleted":33,"total":3},"subIssues":{"nodes":[{"number":601,"title":"Sub 601"},{"number":602,"title":"Sub 602"},{"number":603,"title":"Sub 603"}]}}
+]
+JSON
+    ;;
+  "pr list")
+    echo "[]"
+    ;;
+  "api user")
+    echo "me"
+    ;;
+  "repo view")
+    echo "main"
+    ;;
+  "issue view")
+    echo '{"comments":[]}'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+GHEOF
+chmod +x "$fake_bin_dir3/gh"
+
+cat > "$fake_bin_dir3/git" <<'GITEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "ls-tree" ]]; then
+  printf 'archive\n'
+  exit 0
+fi
+exit 1
+GITEOF
+chmod +x "$fake_bin_dir3/git"
+
+cat > "$fake_bin_dir3/claude" <<'CLAUDEEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "agents" ]]; then
+  echo '[]'
+  exit 0
+fi
+exit 1
+CLAUDEEOF
+chmod +x "$fake_bin_dir3/claude"
+
+out3="$(PATH="$fake_bin_dir3:$PATH" python3 "$board")"
+status3=$?
+check "fixture 3: board.py exits 0" "$status3"
+
+# The whole render, exactly. A section that leaves its trailing blank-line separator behind, or a
+# header with nothing under it, fails here and nowhere else.
+expected3='## Delivery board
+
+(3 ungroomed · 1 epic)'
+if [[ "$out3" == "$expected3" ]]; then status_exact3=0; else status_exact3=1; fi
+check "a board with nothing to report is three lines: the title and the two counts" "$status_exact3"
+
+! echo "$out3" | grep -q "BLOCKED ON YOU"
+check "the BLOCKED ON YOU header does not appear when nothing is blocked on the owner" $?
+
+! echo "$out3" | grep -qE "IN FLIGHT|READY|UNRECOGNIZED|Stalled|Blocked:"
+check "no other section header appears when it has no rows" $?
+
+! echo "$out3" | grep -qE "(^|[ (·])0 "
+check "no zero count is rendered anywhere" $?
+
+! echo "$out3" | grep -q "pending archive"
+check "no 'specs pending archive: 0' text appears when nothing is pending" $?
+
+! echo "$out3" | grep -q "Next up"
+check "no 'next up' line renders when no unclaimed ready issue exists" $?
+
+# ---------------------------------------------------------------------------
+# Fixture 4: "next up" ordering. Four status:ready issues -- P2, unprioritized
+# and P0 unclaimed, plus a P1 claimed by alice. The P0 (#705) is placed out of
+# number order, and the claimed P1 (#706) outranks it by nothing but assignment,
+# so a recommendation that ignores either priority or ownership names the wrong
+# issue.
+# ---------------------------------------------------------------------------
+cat > "$fake_bin_dir4/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue list")
+    cat <<'JSON'
+[
+  {"number":701,"title":"Ready 701","labels":[{"name":"status:ready"},{"name":"P2"}],"url":"https://x/701","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":702,"title":"Ready 702","labels":[{"name":"status:ready"}],"url":"https://x/702","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":705,"title":"Ready 705 top priority","labels":[{"name":"status:ready"},{"name":"P0"}],"url":"https://x/705","assignees":[],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}},
+  {"number":706,"title":"Ready 706 claimed","labels":[{"name":"status:ready"},{"name":"P1"}],"url":"https://x/706","assignees":[{"login":"alice"}],"subIssuesSummary":{"completed":0,"percentCompleted":0,"total":0},"subIssues":{"nodes":[]}}
+]
+JSON
+    ;;
+  "pr list")
+    echo "[]"
+    ;;
+  "api user")
+    echo "me"
+    ;;
+  "repo view")
+    echo "main"
+    ;;
+  "issue view")
+    echo '{"comments":[]}'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+GHEOF
+chmod +x "$fake_bin_dir4/gh"
+
+cat > "$fake_bin_dir4/git" <<'GITEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "ls-tree" ]]; then
+  printf 'issue-1\nissue-2\nissue-3\narchive\n'
+  exit 0
+fi
+exit 1
+GITEOF
+chmod +x "$fake_bin_dir4/git"
+
+cat > "$fake_bin_dir4/claude" <<'CLAUDEEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "agents" ]]; then
+  echo '[]'
+  exit 0
+fi
+exit 1
+CLAUDEEOF
+chmod +x "$fake_bin_dir4/claude"
+
+out4="$(PATH="$fake_bin_dir4:$PATH" python3 "$board")"
+status4=$?
+check "fixture 4: board.py exits 0" "$status4"
+
+echo "$out4" | sed -n '/Next up — activate:/,$p' | grep -q "^  - 705: Ready 705 top priority → /spec-flow:activate 705$"
+check "'next up' names the P0 issue when unclaimed ready issues exist at P0 and P2" $?
+
+! echo "$out4" | grep -qE "activate (701|702)$"
+check "'next up' does not name a lower-priority or unprioritized ready issue" $?
+
+! echo "$out4" | grep -q "activate 706"
+check "'next up' does not name a status:ready issue that already has an assignee" $?
+
+echo "$out4" | grep -qx "🗄️  3 specs pending archive → /spec-flow:archive"
+check "the archive suggestion renders with its count when specs are pending" $?
+
+# Note on prefetch transparency: fixture 1's blocked/needs-attention assertions match exact
+# rendered note text, and are the transparency check -- they must still pass with
+# last_comment_matching()'s calls behind the concurrent prefetch's dict-lookup indirection,
+# proving the parallelized fetch produces the same note content as the serial code it replaced.
 
 echo ""
 echo "----------------------------------------"

--- a/plugins/spec-flow/skills/board/SKILL.md
+++ b/plugins/spec-flow/skills/board/SKILL.md
@@ -12,24 +12,19 @@ anything.
 
 ## Steps
 
-1. **Run the board script — it owns every `gh`/`git`/`claude` call and the entire join.** No raw
-   GitHub JSON belongs in your context for this skill; the script fetches issues, PRs (correlated
-   via `closingIssuesReferences`, not branch-name guessing), CI rollups, local `claude agents`
-   sessions, and the OpenSpec archive-pending count, joins all of it, and prints the finished board
-   text — bucketed (BLOCKED ON YOU / IN FLIGHT / READY / BACKLOG / EPICS), priority-sorted, with
-   "next up" and stalled/blocked/needs-attention already computed:
-   ```bash
-   ${CLAUDE_PLUGIN_ROOT}/scripts/board.py
-   ```
-   Print its stdout directly to the owner — **this IS the board, not raw material to reformat or
-   re-derive.** Pass `--user <login>` only if the owner explicitly wants it scoped to someone other
-   than the authenticated `gh` user; the default (the authenticated user) is almost always right.
-
-2. **Add the one judgment call the script can't make.** If its "Next up" line picked a BACKLOG
-   issue to groom (nothing higher up the ladder was available), look at that issue and say in one
-   line whether it looks too large to spec and land as one unit — suggest splitting it into smaller
-   issues if so. This is genuine judgment (reading the issue's substance), not something
-   mechanical; everything else in the render already reflects the rules below.
+**Run the board script — it owns every `gh`/`git`/`claude` call and the entire join.** No raw
+GitHub JSON belongs in your context for this skill; the script fetches issues, PRs (correlated
+via `closingIssuesReferences`, not branch-name guessing), CI rollups, local `claude agents`
+sessions, and the OpenSpec archive-pending count, joins all of it, and prints the finished board
+text — bucketed (BLOCKED ON YOU / IN FLIGHT / READY), priority-sorted, with "next up",
+stalled/blocked/needs-attention, and counts for the unbounded categories (ungroomed backlog,
+epics) already computed:
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/board.py
+```
+Print its stdout directly to the owner — **this IS the board, not raw material to reformat or
+re-derive.** Pass `--user <login>` only if the owner explicitly wants it scoped to someone other
+than the authenticated `gh` user; the default (the authenticated user) is almost always right.
 
 ## Rules
 


### PR DESCRIPTION
Closes #46.

The delivery board rendered every ungroomed backlog row and every epic's sub-issue list inline. `board/SKILL.md` has the calling model print that stdout verbatim as its own reply, so the text landed in context twice per invocation and persisted in session history. On this repo the board printed 22 lines, 12 of them a backlog dump. It now prints 7.

```
## Delivery board

⛳ BLOCKED ON YOU
  in-review  #46  1️⃣ board.py: report backlog/epics as counts…  @rustyrazorblade  PR #49 ✅ CI  🟢 active

(15 ungroomed · 1 agent:active · 1 local session matched · 1 open PR)

🗄️  4 specs pending archive → /spec-flow:archive
```

## What changed

**BACKLOG and EPICS report as counts.** Neither renders rows. This makes the board's length independent of how large the backlog grows — the property the change is actually after.

**Every line is conditional on having content.** A section with nothing to report contributes no header, no count and no blank line. The summary omits zero counts rather than printing `blocked: 0`. The archive suggestion is its own line, present only when specs are pending.

**"Next up" is one rule:** the highest-priority unclaimed `status:ready` issue, P0 through P3, and silence when there is none. The three recommendations it lost — merge a green PR, unblock a stopped agent, groom a backlog issue — each named an issue that already had an owner driving it. The board reports state; it does not direct work it does not own. BLOCKED ON YOU still renders its rows, because discovering which background session wants you is cross-issue information no single `issue-manager` can provide; it just no longer feeds a recommendation.

**Priority renders as a keycap digit.** Note for anyone touching that column: a keycap is three codepoints but draws in about two cells, so format-width padding misaligns every row.

## Architectural changes

`render_board()` is decomposed into one function per section. Conditional rendering is a per-section decision, and with one function per section each decides for itself and returns nothing when it has nothing.

Blocked/needs-attention comment notes are prefetched concurrently rather than one serial `gh issue view` per row inside `build_rows()`. Same call count, and a single failure — process error or malformed JSON — now falls back for that row alone instead of aborting the batch.

`subIssues` leaves the fetch's `--json` field list along with the three row keys it fed, since nothing reads them once epics report as a count. `subIssuesSummary` stays; `is_epic` reads its `total`.

`SKILL.md`'s bucket list no longer names sections that do not render, and its judgment step is removed — it was conditional on "next up" suggesting a backlog issue to groom, which can no longer happen.

## Why the earlier approach was dropped

An earlier revision of this PR capped the backlog at 10 rows and epic sub-issues at 5, with `--full` to disable both. That approach is gone.

A display cap needed exceptions to stay correct, and one of them could not fail: the spec required that capping "never changes which issue next up recommends", but `backlog` is sorted by `(priority, number)` before the cap takes its prefix, so the top row is always inside the displayed set. An unfalsifiable requirement is a sign the design is working around itself.

The cause underneath was one render serving two categories with opposite growth — delivery state bounded by the pipeline, the backlog bounded by nothing. Counting the second removes the problem instead of shrinking it.

Not addressed here, deliberately: `ISSUE_LIMIT`, pagination, and how much the board fetches. A fetch bound would not reduce context cost — `board.py` is a script, only its stdout reaches a model's context, and the raw JSON never does.

## Tests

`test-board.sh`: 70 assertions, exits 0, `shellcheck` clean.
