### PR TITLE
Remove banned code metaphors from skill and reference docs

### DIFF
--- a/openspec/changes/issue-50/design.md
+++ b/openspec/changes/issue-50/design.md
@@ -61,7 +61,7 @@ Read-the-file is also the stronger fit for two acceptance criteria: if neither p
 
 Disambiguation is a leading slash. The script additionally rejects `..` and any character outside `[A-Za-z0-9._/-]`.
 
-**That character restriction is load-bearing, not fussiness.** It is what makes the emitted pointer provably free of backticks, `$`, and braces — so embedding it in a string literal is safe by construction rather than by escaping at the point of use.
+**That character restriction is required, not fussiness.** It is what makes the emitted pointer provably free of backticks, `$`, and braces — so embedding it in a string literal is safe by construction rather than by escaping at the point of use.
 
 ### D3a — The repo root is guarded too, and the guard is narrow
 

--- a/openspec/changes/issue-53/proposal.md
+++ b/openspec/changes/issue-53/proposal.md
@@ -91,7 +91,7 @@ YAMLs the owner copies into `.github/`), `refactoring-discipline.md` (read by `t
 the template (read only during seeding) — so a contributor browsing the directory learns the
 no-runtime-read rule without opening the file. It also states the
 `<destination-filename>.template` naming convention as a convention, binding on any template whose
-destination is a single named file rather than on this one file. The qualifier is load-bearing: the
+destination is a single named file rather than on this one file. The qualifier is necessary: the
 workflow YAMLs in `ci/` have no single destination, because the owner picks one by runner and names
 the copied file, so the convention cannot reach them and does not claim to.
 

--- a/plugins/cassandra-expert/.claude-plugin/plugin.json
+++ b/plugins/cassandra-expert/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cassandra-expert",
   "description": "Expert guidance for Apache Cassandra development, including schema design, query optimization, performance tuning, and operational best practices.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Jon Haddad"
   },

--- a/plugins/cassandra-expert/.codex-plugin/plugin.json
+++ b/plugins/cassandra-expert/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-expert",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Expert guidance for Apache Cassandra development, including schema design, query optimization, performance tuning, and operational best practices.",
   "author": {
     "name": "Jon Haddad"

--- a/plugins/cassandra-expert/references/general/token-skew.md
+++ b/plugins/cassandra-expert/references/general/token-skew.md
@@ -179,7 +179,7 @@ Mixing these two analyses leads to incorrect conclusions about root cause and in
 
 ## The Per-Rack vs Full-Ring Distinction
 
-### Mathematical Foundation
+### The Mathematics
 
 With NTS, when a keyspace has RF == rack count (e.g., RF=3 with 3 racks), every partition is replicated to all 3 racks. A node's data within its rack is determined by the gap between it and the next same-rack node — cross-rack tokens in between are irrelevant.
 

--- a/plugins/cassandra-expert/references/training/01-fundamentals/01-data-distribution.md
+++ b/plugins/cassandra-expert/references/training/01-fundamentals/01-data-distribution.md
@@ -4,7 +4,7 @@
 Understand how Cassandra decides which node stores which data, and why that decision is entirely determined by the partition key.
 
 ## Why This Matters
-Every performance problem in Cassandra eventually traces back to data distribution. If you don't understand how data is placed, you can't reason about hot spots, replication, consistency, or query performance. This is the foundational mental model for everything else.
+Every performance problem in Cassandra eventually traces back to data distribution. If you don't understand how data is placed, you can't reason about hot spots, replication, consistency, or query performance. This is the core mental model for everything else.
 
 ## Why We Start Here (Not With Tables)
 

--- a/plugins/cassandra-expert/references/training/01-fundamentals/12-table-options.md
+++ b/plugins/cassandra-expert/references/training/01-fundamentals/12-table-options.md
@@ -4,7 +4,7 @@
 Know the table-level properties you'll set when creating or altering tables, what each one does, and when to override the defaults.
 
 ## Why This Matters
-Every `CREATE TABLE` statement accepts a `WITH` clause that configures how the table behaves — how it's compacted, how long tombstones linger, how it's cached, how rows are compressed, and more. Most of these defaults are reasonable, but several are worth knowing about explicitly because they directly affect data modeling decisions, disk usage, and read/write behavior. Understanding table options is also the foundation for knowing what you can and can't change after a table is created.
+Every `CREATE TABLE` statement accepts a `WITH` clause that configures how the table behaves — how it's compacted, how long tombstones linger, how it's cached, how rows are compressed, and more. Most of these defaults are reasonable, but several are worth knowing about explicitly because they directly affect data modeling decisions, disk usage, and read/write behavior. You also need to understand table options to know what you can and can't change after a table is created.
 
 ---
 

--- a/plugins/cassandra-expert/references/training/04-sai/01-sai-overview.md
+++ b/plugins/cassandra-expert/references/training/04-sai/01-sai-overview.md
@@ -34,7 +34,7 @@ The syntax is deliberately simple:
 CREATE INDEX users_by_email ON users (email) USING 'sai';
 ```
 
-The next topic ([What SAI Is and Why the Partition Key Rule Exists](./02-what-is-sai.md)) covers *how* this works at the storage layer, and why the partition key rule is load-bearing.
+The next topic ([What SAI Is and Why the Partition Key Rule Exists](./02-what-is-sai.md)) covers *how* this works at the storage layer, and why the partition key rule exists.
 
 ### The One Rule
 
@@ -48,7 +48,7 @@ The next topic explains why, in detail. For now: commit the rule to memory and b
 
 | Topic | What you'll learn |
 |---|---|
-| [What SAI Is](./02-what-is-sai.md) | The per-SSTable storage model and why the partition key rule is load-bearing. |
+| [What SAI Is](./02-what-is-sai.md) | The per-SSTable storage model and why the partition key rule exists. |
 | [Creating and Managing SAI Indexes](./03-creating-managing-indexes.md) | Syntax, naming, building, dropping, and operational considerations. |
 | [Querying with SAI](./04-querying-with-sai.md) | Query patterns that work, patterns that don't, and how to identify problem queries. |
 | [SAI vs. Denormalization](./05-sai-vs-denormalization.md) | When to use SAI and when to reach for a dedicated table instead. |

--- a/plugins/cassandra-expert/skills/training/SKILL.md
+++ b/plugins/cassandra-expert/skills/training/SKILL.md
@@ -50,7 +50,7 @@ You are an expert Cassandra instructor with deep real-world production experienc
 
 #### Session 1: Fundamentals
 **File:** `sessions/01-fundamentals.md`
-**Audience:** Developers new to Cassandra or looking to build a solid foundation.
+**Audience:** Developers new to Cassandra or unsure of the basics.
 **Topics:** Data distribution, keyspaces, types, partition design, table patterns, application best practices.
 
 #### Session 2: Query & Application Anti-Patterns

--- a/plugins/cassandra-expert/skills/training/sessions/01-fundamentals.md
+++ b/plugins/cassandra-expert/skills/training/sessions/01-fundamentals.md
@@ -1,6 +1,6 @@
 # Session 1: Cassandra Fundamentals
 
-**Audience:** Developers new to Cassandra or building on shaky foundations.
+**Audience:** Developers new to Cassandra or unsure of the basics.
 **Goal:** Understand how Cassandra stores and distributes data, how to design tables correctly, and how to write applications that use Cassandra well.
 
 ---
@@ -50,7 +50,7 @@
 >
 > This session touches three things: **architecture**, **data modeling**, and **query patterns**. In a relational database you can mostly treat these as separate concerns — you learn SQL, you design tables against third normal form, and the database figures out how to execute your queries efficiently. Cassandra doesn't work that way. These three are deeply interrelated, and you can't make good decisions about any one of them without understanding the other two.
 >
-> - **Architecture** — how data is distributed across nodes, how writes and reads flow through the cluster, how replicas reconcile. This isn't "ops trivia" you can skip as a developer. It's the foundation that dictates the rules of data modeling.
+> - **Architecture** — how data is distributed across nodes, how writes and reads flow through the cluster, how replicas reconcile. This isn't "ops trivia" you can skip as a developer. It dictates the rules of data modeling.
 > - **Data modeling** — how you lay out partitions, choose clustering columns, and design tables. Every choice here is a direct consequence of the architecture. A partition key isn't just an identifier; it's the thing that decides which node your data lives on and whether your workload creates hot spots.
 > - **Query patterns** — what queries you're allowed to run efficiently, and what queries will burn the cluster down. In Cassandra, the query patterns you need *drive the table design*, not the other way around. There's no query planner to save you — if the table isn't designed for the query, the query either doesn't work or takes down production.
 >

--- a/plugins/dev-skills/.claude-plugin/plugin.json
+++ b/plugins/dev-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-skills",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Language developer agents and generic development skills: rust-dev + cargo for Rust; kotlin-dev + gradle-expert for Kotlin and the JVM; java-dev for convention-matching Java work; refactor for behavior-preserving work in any language; tech-debt for a repo-wide structural audit; complexity-reduction to measure cognitive complexity and duplication with PMD or rust-code-analysis-cli, over a subsystem or a diff; ide-explain and walkthrough to render a change as a self-contained HTML page; prose-review to grade comments, commit messages, and PR descriptions. Pairs with spec-flow, which delegates to whichever developer agent a repo configures.",
   "author": {
     "name": "Jon Haddad"

--- a/plugins/dev-skills/references/prose-style.md
+++ b/plugins/dev-skills/references/prose-style.md
@@ -119,7 +119,7 @@ than one call site, anchor it at each site — consolidating into one comment
 elsewhere loses the guarantee exactly where it is needed.
 
 Length tracks the count of independent, non-inferable facts, not an
-arbitrary line cap. A comment with four load-bearing facts (e.g., "this call
+arbitrary line cap. A comment with four non-inferable facts (e.g., "this call
 resets state X; that makes value Y unreliable for case Z; the obvious
 alternative source for Y doesn't work either, because W") earns four
 clauses. Cutting a comment to one line when it carries three non-inferable

--- a/plugins/dev-skills/skills/ide-explain/SKILL.md
+++ b/plugins/dev-skills/skills/ide-explain/SKILL.md
@@ -189,7 +189,7 @@ nodes: [
 ]
 ```
 
-## Display constraint (load-bearing)
+## Display constraint
 
 A background/headless caller (a spawned agent process, a CI job) cannot reliably open a browser on
 the owner's screen — there is no display to open one on. The contract in that case is: **generate

--- a/plugins/dev-skills/skills/prose-review/SKILL.md
+++ b/plugins/dev-skills/skills/prose-review/SKILL.md
@@ -164,7 +164,7 @@ that starts from the old wording inherits the old residue.
 2. List the facts the reader needs that the artifact's own context cannot state for itself.
 3. Cut from that list every fact `prose-style.md` says to cut for this artifact.
 4. Write the replacement from the surviving list alone.  Do not reread the old text yet.
-5. Now read the old text once.  Look only for a load-bearing fact you missed.  If you find one, add
+5. Now read the old text once.  Look only for a non-inferable fact you missed.  If you find one, add
    it to the list and write again from the list.  Never paste the old phrasing back.
 6. Check the anchor.  A mechanism-level comment belongs at the operation it protects, not at a type
    declaration or an enclosing method.  If the same invariant is relied on at several sites, anchor

--- a/plugins/dev-skills/skills/walkthrough/SKILL.md
+++ b/plugins/dev-skills/skills/walkthrough/SKILL.md
@@ -17,7 +17,7 @@ diff, an issue, a PR — as a file tree the owner navigates themselves. `walkthr
 for `ide-explain` when the subject is "what changed"; reach for this when the subject is "how this
 works", "what's wrong with this", or "what we should do about it".
 
-## The load-bearing part: you author everything
+## The core requirement: you author everything
 
 `generate-walkthrough.py` derives nothing. It never shells out to `git`, `gh`, or an AST tool; it
 validates your manifest and renders it, full stop. The diagram, the ordering, the narration, and
@@ -153,7 +153,7 @@ Note the two things that carry the meaning: the box the walkthrough is *about* i
 (`&#8594;`), not characters that depend on the reader's font. For a branching or layered shape,
 switch to `type: "svg"` with a `viewBox` — same colors, same restraint.
 
-## Display constraint (load-bearing)
+## Display constraint
 
 A background/headless caller (a spawned agent process, a CI job) cannot reliably open a browser on
 the owner's screen — there is no display to open one on. The contract in that case is: **generate

--- a/plugins/easy-db-lab/.claude-plugin/plugin.json
+++ b/plugins/easy-db-lab/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "easy-db-lab",
   "description": "Guided workflow assistant for easy-db-lab — provision AWS lab environments, manage Cassandra and ClickHouse clusters, run stress tests, and operate observability tooling.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": {
     "name": "Jon Haddad"
   },

--- a/plugins/easy-db-lab/.codex-plugin/plugin.json
+++ b/plugins/easy-db-lab/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-db-lab",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Guided workflow assistant for easy-db-lab \u2014 provision AWS lab environments, manage Cassandra and ClickHouse clusters, run stress tests, and operate observability tooling.",
   "author": {
     "name": "Jon Haddad"

--- a/plugins/easy-db-lab/skills/plan/SKILL.md
+++ b/plugins/easy-db-lab/skills/plan/SKILL.md
@@ -49,7 +49,7 @@ If the binary cannot be found, load `../../references/commands.md` as a fallback
 
 ### `commands` is the index, not the documentation — run `--help` per command
 
-**`$EDB commands` prints only a one-line description per subcommand. It silently drops the full help text, which is where the load-bearing warnings live.** Treat it as a table of contents for finding what exists, then read the actual entry.
+**`$EDB commands` prints only a one-line description per subcommand. It silently drops the full help text, which is where the critical warnings live.** Treat it as a table of contents for finding what exists, then read the actual entry.
 
 **Once you know which commands the plan will use, run `--help` on each one** before writing any step that invokes it:
 

--- a/plugins/spec-flow/.claude-plugin/plugin.json
+++ b/plugins/spec-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-flow",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Session-driven multi-agent delivery pipeline: groom → activate (spec) → implement (5-lens review panel) → address → finalize, over OpenSpec + GitHub.",
   "author": { "name": "Jon Haddad" },
   "repository": "https://github.com/rustyrazorblade/skills",

--- a/plugins/spec-flow/docs/workflow.md
+++ b/plugins/spec-flow/docs/workflow.md
@@ -768,8 +768,8 @@ individual mandates are described once, in full, in **Review panel** below — n
 ## Developer agent
 
 `tdd-developer` is bundled with this plugin and is the default. It is language-neutral by design:
-it carries the TDD loop, the SOLID rules, and the refactoring discipline, plus a thin layer of
-per-language style.
+it carries the TDD loop, the SOLID rules, and the refactoring discipline, plus a small set of
+per-language style rules.
 
 Deep language expertise lives elsewhere, in the standalone **`dev-skills`** plugin. Its `rust-dev`
 agent reads the full Rust style guide, carries a nextest recipe tuned for low token use, and
@@ -1012,7 +1012,7 @@ permit pushing the issue branch.
 **The real boundary.** Running spec-flow's panel over a diff executes commands that diff controls.
 That is what the pipeline is for, not a defect in it — and it means **spec-flow must not be pointed
 at an untrusted third-party branch.** The control at that boundary is the permission and sandbox
-layer the session runs under, not prose in a prompt. What the pipeline does enforce mechanically is
+mechanism the session runs under, not prose in a prompt. What the pipeline does enforce mechanically is
 narrower and worth stating exactly: the policy file must be a real file physically inside the
 repository, so a committed symlink cannot redirect that read to `~/.ssh/id_rsa` or anything else
 outside the tree. That is a path check rather than a content check, which is why it coexists with


### PR DESCRIPTION
## What

The `ste-house-style` output style bans code metaphors for abstractions:

> Avoid Code metaphors for abstractions: "seam," "load-bearing," "foundation," "layer," "paradigm shift." Name the real thing: boundary, dependency, prerequisite.

The repo's own skill and reference docs used several of them. This removes them.

Prose only. No script, config, or behavior change.

## Changed

- **`load-bearing` — 10 sites.** `dev-skills` walkthrough, ide-explain, prose-review, prose-style; `easy-db-lab` plan; `cassandra-expert` SAI overview; two `openspec/changes/` records.
- **`foundation` — 6 sites**, all `cassandra-expert` training material.
- **`layer` — 2 sites** in `plugins/spec-flow/docs/workflow.md`, the only two used as a vague metaphor.

## Deliberately unchanged

- **`Seam 1` / `Seam 2`** — spec-flow's defined names for the owner's two approval stops, 156 occurrences across `docs/workflow.md`, `issue-manager.md`, `project-manager.md`, and the stage skills. Renaming the pipeline's shared vocabulary is a separate change with real behavior risk, not a text fix.
- **`unnecessary layering`** — the name of a code smell the `/tech-debt` audit looks for.
- **`storage layer`**, **`layer X on top`**, **`package by feature, not by layer`** — literal architecture terms, not metaphors.
- **`Apache Software Foundation`** — a proper name.

## Versions

Patch bumps on the four plugins touched:

| Plugin | Version |
|---|---|
| `cassandra-expert` | 0.10.0 → 0.10.1 |
| `dev-skills` | 0.4.0 → 0.4.1 |
| `easy-db-lab` | 0.11.0 → 0.11.1 |
| `spec-flow` | 0.43.0 → 0.43.1 |

`cassandra-expert` and `easy-db-lab` have both `.claude-plugin` and `.codex-plugin` manifests; both were updated. `dev-skills` and `spec-flow` have only `.claude-plugin`.

## Review

A review pass checked meaning preservation, markdown anchors, and the version bumps. It found no broken links: nothing in the repo pointed at the one changed heading (`### Mathematical Foundation` in `token-skew.md`). Five wordings were tightened on its findings, including using each document's own existing term (`non-inferable`) instead of a generic replacement.
