### PR TITLE
Agents must never present findings by internal identifier, and must ask one question at a time

### DIFF
--- a/openspec/changes/issue-82/ac-coverage.md
+++ b/openspec/changes/issue-82/ac-coverage.md
@@ -1,0 +1,16 @@
+# Acceptance-criteria coverage — issue 82
+
+| Source | Requirement | Covering scenario(s) | Status |
+|--------|-------------|----------------------|--------|
+| AC | A finding is stated in plain terms before any identifier; the identifier is optional trailing context | `owner-presentation: Relaying a review-panel finding` | ✅ Covered |
+| AC | Several findings/decisions are presented one at a time by default, waiting before the next | `owner-presentation: Several findings after a review round` | ✅ Covered |
+| AC | The owner may ask for the whole set at once; the override applies to that request only | `owner-presentation: The owner asks for the whole set` | ✅ Covered |
+| AC | A cited file, line, scenario, or task number says what is there, not just names it | `owner-presentation: Citing a file and line` | ✅ Covered |
+| AC | Each option states its cost as well as its effect; the recommended one is marked | `owner-presentation: Options with a recommendation`; `owner-presentation: A decision the agent must not steer` | ✅ Covered |
+| AC | A relayed finding is not presented in the author's vocabulary without translation | `owner-presentation: Relaying a review-panel finding` | ✅ Covered |
+| Risk | A pointer alone would not change behavior; the emitting instruction must be fixed in place | tasks 2.1–2.7 fix each site in place, not only via a pointer | ✅ Covered |
+| Risk | The contract must not forbid deliberate batch presentations (board, coverage tables, PR residual lists) | `owner-presentation: The board renders many items`; `owner-presentation: A finding written into a PR body` | ✅ Covered |
+| Risk | The contract must not falsify groom's "the only exception" claim | `owner-presentation: groom's bulk assumption confirm` | ✅ Covered |
+| Risk | The 0.46.0 sentence must not contradict AC1's trailing-tag allowance | `owner-presentation: The 0.46.0 spec-identifier sentence` | ✅ Covered |
+| Risk | One-at-a-time cannot apply to one-shot written artifacts (PR body, comment) | `owner-presentation: A finding written into a PR body` | ✅ Covered |
+| Risk | "Every agent" must not bind review subagents that never present to the owner | `owner-presentation: A review subagent returns findings to its lead` | ✅ Covered |

--- a/openspec/changes/issue-82/design.md
+++ b/openspec/changes/issue-82/design.md
@@ -1,0 +1,117 @@
+# Design — issue 82: owner presentation contract
+
+## Context
+
+This change edits instruction prose only. There is no runtime, no data model, and no interface in
+the usual sense. "Design" here means three things: where the contract text lives, how it binds every
+owner-facing presenter, and how the contract avoids forbidding the deliberate batch presentations
+that already exist.
+
+The architect and design-critic both ran before the owner chose. design-critic found the first draft
+could not meet its acceptance criteria as written. The decisions below resolve every blocker it
+raised.
+
+## Decisions
+
+### Where the contract lives: central block plus in-place fixes
+
+The contract is one canonical block in `docs/workflow.md`. Each owner-facing presenter also gets its
+concrete emitting instruction fixed in place — the instruction that produces the finding text or the
+option list — not just a pointer to the block.
+
+design-critic showed that a pointer alone would not change behavior. The real violation lives in
+concrete instructions. For example, `implement` tells the lead to write the residual findings list
+straight from the lens JSON, whose fields include the identifier. A pointer at the top of the file
+leaves that instruction standing. So each emitting site is edited to state findings in plain terms,
+with the identifier as a trailing tag.
+
+The central block prevents drift. The contract will otherwise be restated in seven files, and this
+whole issue exists because a rule stated in one place did not bind another.
+
+### The 0.46.0 sentence is reworded, not kept verbatim
+
+The owner first asked to keep the 0.46.0 sentence verbatim. design-critic then showed the sentence
+contradicts acceptance criterion 1: "never cite a spec section by its identifier" forbids the very
+trailing tag the criterion allows. The owner chose to reword it. The new sentence forbids an
+identifier as the subject or the sole referent, and allows it as an optional trailing tag. This
+matches the contract and removes the contradiction.
+
+### The batch carve-outs are enumerated, and groom is reconciled
+
+The contract governs decisions, findings, and questions. It does not govern deliberate batch
+presentations: status summaries (the board), read-only check batches (`setup` step 1), and
+whole-artifact reviews (Seam 1's coverage tables, `implement`'s residual findings list in a PR body).
+The contract names these so it cannot be read as forbidding them.
+
+`groom` step 4 calls its bulk assumption confirm "the only exception to the one-question rule." Since
+the contract now names several deliberate batches, that line is reworded to point at the contract's
+list rather than claim to be the only one.
+
+### Every owner-facing presenter is bound
+
+Acceptance criterion 6 binds "every agent" that presents to the owner. The owner confirmed the intent
+is consistency across all skills, not only the three demonstrated failure sites. So the contract
+binds `issue-manager`, `implement`, `address`, `activate`, `groom`, `setup`, and `project-manager`.
+
+The review subagents (`architect`, `product-manager`, `design-critic`, `reviewer`) are not bound.
+They return structured output to a relayer; they never present to the owner. Binding them would
+contradict the scope's carve-out that keeps the panel's JSON identifiers intact.
+
+### Plain terms apply everywhere; one-at-a-time applies to live turns
+
+design-critic noted that two bound files present through PR bodies and issue comments, which are
+one-shot writes with no turn to wait for. So the contract splits its rules by presentation kind:
+
+- **Plain terms, identifier as trailing tag, translate a relayed finding's words** — applies to every
+  presentation, interactive or written into an artifact.
+- **One decision at a time, wait for an answer before the next** — applies to interactive decision
+  points, where the owner answers.
+
+## Alternatives Considered
+
+### Where the contract text lives
+
+- **Central block plus in-place fixes at each site (chosen).** One canonical block for the wording
+  and the reasoning, plus an edit to each concrete emitting instruction so behavior changes at the
+  failure point. Cost: more surface to touch and one reference hop. Chosen because design-critic
+  showed a pointer alone leaves the id-emitting instructions standing.
+- **Restate the full rule at each site, no central block (rejected).** Matches how the repo already
+  restates some behavioral rules. Rejected: it manufactures the duplication-drift this issue fights,
+  across seven files.
+- **Central block plus pointers only, no in-place edits (rejected, the architect's first draft).**
+  Lowest effort. Rejected: design-critic judged it would not change behavior, because the emitting
+  instructions would stand unchanged.
+
+### The 0.46.0 sentence
+
+- **Reword to allow a trailing tag (chosen).** Consistent with acceptance criterion 1. Cost: edits
+  text the owner first asked to keep verbatim.
+- **Keep verbatim as an absolute ban (rejected).** Would leave two different rules for two identifier
+  kinds, with the same `C8` example on both sides.
+
+### The batch carve-outs
+
+- **Enumerate the carve-outs and reword groom's "only one" line (chosen).** Explicit and correct.
+  Cost: touches `groom`, which the scope marked partly out of bounds.
+- **Scope the contract narrowly and leave groom untouched (rejected).** Keeps the issue tight, but
+  leaves groom's "the only one" claim stale.
+- **Enumerate but leave groom untouched (rejected).** A known inconsistency between two documents.
+
+### Reach beyond the three named files
+
+- **Bind every owner-facing presenter (chosen).** The owner confirmed the goal is consistency across
+  all skills. Cost: more files than the scope's list names.
+- **Three named files plus activate only (rejected).** Leaves the central coordinator, the agent the
+  owner talks to most, outside the rule.
+
+## How this is verified
+
+Prose has no unit test. "Tested" here means demonstrated and audited:
+
+1. **A worked before/after example per acceptance criterion**, committed in this change under
+   `verification.md`. Each pair shows a bad presentation and its compliant rewrite. This is the real
+   proof the contract bites.
+2. **A coverage checklist** mapping each acceptance criterion to the exact file and line that
+   satisfies it, plus a scan confirming no bound file still tells an agent to present the owner a
+   bare identifier as a referent.
+3. **The review panel's spec lens** checks the committed prose against each scenario in this change.

--- a/openspec/changes/issue-82/overrides.md
+++ b/openspec/changes/issue-82/overrides.md
@@ -1,0 +1,21 @@
+# Overrides and conflicts — issue 82
+
+## Overrides existing behavior
+
+None — this change only adds a new capability, `owner-presentation`. It modifies no existing baseline
+requirement in `openspec/specs/`.
+
+Note: the change edits instruction prose in several plugin files, including one sentence added in
+release 0.46.0. That is an edit to instruction text, not an override of a committed spec requirement.
+No baseline spec covers the presentation contract today.
+
+## Conflicts with other in-flight changes
+
+`issue-77` is the only other open change. It modifies the `idea-refinement` capability (groom's
+refinement loop). This change adds the `owner-presentation` capability and does not touch
+`idea-refinement`. No actual conflict.
+
+`issue-77` and this change both edit `skills/groom/SKILL.md`, but different parts: `issue-77` reworks
+step 4's refinement loop; this change rewords step 4's "the only exception" sentence. If `issue-77`
+merges first, confirm that sentence still exists before rewording it; the edit is small and
+independent either way.

--- a/openspec/changes/issue-82/proposal.md
+++ b/openspec/changes/issue-82/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+When an agent brings the owner findings or decisions, two failures repeat and compound each other.
+
+First, agents name findings by internal identifiers. The review panel's lenses tag their findings
+`C8`, `SEC-3`, `F1`, `OBS-1`. Those tags are internal to the panel's JSON contract. They mean
+something to the lens that emitted them and to nothing else. Agents then relay them to the owner as
+if they were shared words: "should I fix C8 and SEC-3 before Build?" The owner does not know what
+those are. The same happens with `file:line` references, spec scenario titles, and task numbers used
+as though the owner had them open.
+
+Second, agents hand the owner several decisions at once. A single message carries four or five
+choices, each with options. The owner cannot answer a batch. The owner must scroll back past detail
+to find the one thing being asked.
+
+Both happened in one session on issue 77: five findings, all named by lens code, none described.
+
+The rule exists in two skills already (`groom` step 1, `activate` step 1) and in the owner's own
+`CLAUDE.md`. It does not bind the path where it breaks: an agent relaying panel findings, or any
+agent presenting a list of choices. This change makes the rule a single contract that binds every
+owner-facing presenter in the plugin, so all skills present consistently.
+
+## What Changes
+
+- **A single presentation contract lands in `docs/workflow.md`.** It states four rules: plain terms
+  before any identifier; one decision at a time by default; the owner may override to a batch; every
+  option states its cost and marks the recommended one where one exists. It names the deliberate
+  batch presentations it does not govern (status summaries, whole-artifact reviews).
+- **Every owner-facing presenter is bound to the contract, and its concrete emitting instructions
+  are fixed in place** — not merely pointed at the contract. The bound files are
+  `agents/issue-manager.md`, `skills/implement/SKILL.md`, `skills/address/SKILL.md`,
+  `skills/activate/SKILL.md`, `skills/groom/SKILL.md`, `skills/setup/SKILL.md`, and
+  `agents/project-manager.md`.
+- **The 0.46.0 sentence in `issue-manager.md` is reworded.** Today it reads "never cite a spec
+  section by its identifier," which forbids even the trailing tag this contract allows. It is
+  reworded to forbid an identifier only as the subject or the sole referent.
+- **`groom`'s "the only exception" claim is reconciled.** `groom` step 4 calls its bulk assumption
+  confirm "the only exception to the one-question rule." The contract now names several deliberate
+  batch presentations, so that line is reworded to point at the contract's list instead of claiming
+  to be the only one.
+- **`activate` step 1 gains the missing half.** It states "one at a time" but omits the
+  recommended-default half that `groom` states. The contract's "mark the recommended option where
+  you have one" is added there.
+- **The plain-terms rules apply to asynchronous artifacts too.** A finding written into a PR body or
+  an issue comment must also be stated in plain terms, with the identifier as a trailing tag only.
+  The "one at a time, wait for an answer" rule applies to interactive decision points, where the
+  owner answers before the next.
+
+## Scope
+
+**In:** the presentation contract in `docs/workflow.md`; compliant edits to every owner-facing
+presenter listed above; the reword of the 0.46.0 sentence; the reconcile of `groom`'s "only one"
+line; the `activate` step 1 addition.
+
+**Out:** the panel's JSON contract (lenses keep emitting identifiers); the agent-to-agent channel
+(an identifier passed lead to fix agent is correct and stays); re-litigating the one-at-a-time rule
+where it already works.

--- a/openspec/changes/issue-82/specs/owner-presentation/spec.md
+++ b/openspec/changes/issue-82/specs/owner-presentation/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: A finding is stated in plain terms before any identifier
+An agent presenting a finding to the owner SHALL state what is wrong in plain terms first. An
+internal identifier (a review-panel finding tag, a spec section, a task number) MAY appear only as a
+trailing tag. The identifier SHALL NOT be the subject of the sentence, and SHALL NOT be the only
+referent. When an agent relays a finding it did not author, it SHALL translate the author's words
+and SHALL NOT adopt the author's vocabulary unchanged.
+
+#### Scenario: Relaying a review-panel finding
+- **WHEN** an agent relays a lens finding tagged `SEC-3` to the owner
+- **THEN** it states the problem in plain terms, for example "the auth token is written to the log in
+  plaintext"
+- **AND** the tag `SEC-3` appears only as a trailing tag, never as "should I fix SEC-3?"
+
+#### Scenario: The 0.46.0 spec-identifier sentence
+- **WHEN** an agent refers to a spec section while presenting to the owner
+- **THEN** it states what the section requires in plain terms
+- **AND** it MAY add the section identifier as a trailing tag, rather than being forbidden every
+  identifier
+
+### Requirement: A cited location is described, not just named
+When an agent cites a file, a line, a spec scenario, or a task number to the owner, it SHALL say what
+is there. The agent SHALL NOT assume the owner has the file or the artifact open.
+
+#### Scenario: Citing a file and line
+- **WHEN** an agent points the owner at `reviewer.md:120`
+- **THEN** it says what that line instructs or contains, not the location alone
+
+### Requirement: Decisions are presented one at a time by default
+When an agent has several findings or decisions for the owner, it SHALL present them one at a time by
+default and SHALL wait for an answer before presenting the next. This rule governs interactive
+decision points, where the owner answers.
+
+#### Scenario: Several findings after a review round
+- **WHEN** a review round returns five findings that need the owner's decision
+- **THEN** the agent presents the first, waits for the owner's answer, then presents the next
+- **AND** it does not present all five in one message
+
+### Requirement: The owner may override to a batch
+The owner MAY ask for a whole set at once. When the owner does, the agent SHALL present the set
+together. That override SHALL apply to that request only, and the agent SHALL NOT assume it for later
+presentations.
+
+#### Scenario: The owner asks for the whole set
+- **WHEN** the owner says "give me all the findings at once"
+- **THEN** the agent presents them together for that request
+- **AND** the agent returns to one-at-a-time for the next set, without being told again
+
+### Requirement: Options state their cost, and the recommended one is marked where one exists
+When an agent lists options for a decision, each option SHALL state what it costs as well as what it
+does. The agent SHALL mark the recommended option where it has a recommendation. Where the decision
+is deliberately the owner's and the agent withholds a recommendation, it SHALL present the options
+unmarked and SHALL say the choice is the owner's.
+
+#### Scenario: Options with a recommendation
+- **WHEN** an agent lists three design options
+- **THEN** each option states its cost and its effect
+- **AND** the recommended option is marked
+
+#### Scenario: A decision the agent must not steer
+- **WHEN** an agent presents the tech-debt escalation options, which it must not choose for the owner
+- **THEN** it presents the options unmarked and says the choice is the owner's
+
+### Requirement: Plain terms apply to written artifacts; one-at-a-time applies to live turns
+The plain-terms rules SHALL apply to every presentation, whether interactive or written into an
+artifact such as a PR body or an issue comment. The one-at-a-time rule and its wait SHALL apply to
+interactive decision points, not to a one-shot written artifact.
+
+#### Scenario: A finding written into a PR body
+- **WHEN** an agent writes residual findings into a PR body
+- **THEN** each finding is stated in plain terms with the identifier as a trailing tag
+- **AND** the agent is not required to split the list across separate writes and wait between them
+
+### Requirement: Deliberate batch presentations are exempt
+The contract SHALL name the deliberate batch presentations it does not govern: status summaries such
+as the board, read-only check batches, and whole-artifact reviews such as Seam 1 coverage tables and
+a residual findings list. An agent presenting one of these SHALL NOT be forced to split it into one
+item at a time.
+
+#### Scenario: The board renders many items
+- **WHEN** the board renders the state of many issues at once
+- **THEN** the contract does not require the board to present one issue at a time
+
+#### Scenario: groom's bulk assumption confirm
+- **WHEN** `groom` step 4 presents its bulk assumption confirm
+- **THEN** the wording points at the contract's list of exempt batches
+- **AND** it does not claim to be the only exception to the one-question rule
+
+### Requirement: Every owner-facing presenter is bound
+Every agent or skill that presents findings, options, or questions to the owner SHALL follow this
+contract. The bound presenters are `issue-manager`, `implement`, `address`, `activate`, `groom`,
+`setup`, and `project-manager`. A review subagent that returns structured output to a relayer, and
+never presents to the owner, is not bound.
+
+#### Scenario: The central coordinator presents a decision
+- **WHEN** `project-manager` asks the owner which issue to start next
+- **THEN** it follows the contract, the same as any other bound presenter
+
+#### Scenario: A review subagent returns findings to its lead
+- **WHEN** a lens returns findings tagged with identifiers to its lead agent
+- **THEN** the identifiers are correct on that agent-to-agent channel and are not changed by this
+  contract

--- a/openspec/changes/issue-82/tasks.md
+++ b/openspec/changes/issue-82/tasks.md
@@ -2,13 +2,13 @@
 
 ## 1. The canonical contract
 
-- [ ] 1.1 Add a "Presenting to the owner" section to `docs/workflow.md` with the four rules: plain
+- [x] 1.1 Add a "Presenting to the owner" section to `docs/workflow.md` with the four rules: plain
       terms before any identifier; one decision at a time by default; the owner may override to a
       batch; every option states its cost and marks the recommended one where one exists.
-- [ ] 1.2 In that section, split the rules by kind: plain terms and translate-the-words apply to
+- [x] 1.2 In that section, split the rules by kind: plain terms and translate-the-words apply to
       every presentation including PR bodies and comments; one-at-a-time and its wait apply to
       interactive decision points.
-- [ ] 1.3 In that section, name the deliberate batch presentations the contract does not govern:
+- [x] 1.3 In that section, name the deliberate batch presentations the contract does not govern:
       status summaries (the board), read-only check batches (`setup` step 1), whole-artifact reviews
       (Seam 1 coverage tables, `implement`'s residual findings list).
 

--- a/openspec/changes/issue-82/tasks.md
+++ b/openspec/changes/issue-82/tasks.md
@@ -14,21 +14,21 @@
 
 ## 2. Fix each owner-facing presenter in place
 
-- [ ] 2.1 `agents/issue-manager.md`: reword the 0.46.0 sentence to forbid an identifier only as
+- [x] 2.1 `agents/issue-manager.md`: reword the 0.46.0 sentence to forbid an identifier only as
       subject or sole referent, allow it as a trailing tag; add the panel-finding relay rule and the
       one-at-a-time default to the relay path; reference the contract.
-- [ ] 2.2 `skills/implement/SKILL.md`: fix the fix-round and gate-failure emitting instructions so
+- [x] 2.2 `skills/implement/SKILL.md`: fix the fix-round and gate-failure emitting instructions so
       residual findings are stated in plain terms with the identifier as a trailing tag; reference
       the contract.
-- [ ] 2.3 `skills/address/SKILL.md`: fix the report path so findings are stated in plain terms;
+- [x] 2.3 `skills/address/SKILL.md`: fix the report path so findings are stated in plain terms;
       reference the contract.
-- [ ] 2.4 `skills/activate/SKILL.md`: add the missing recommended-default half to step 1 ("with a
+- [x] 2.4 `skills/activate/SKILL.md`: add the missing recommended-default half to step 1 ("with a
       recommended answer where you have one"); reference the contract.
-- [ ] 2.5 `skills/groom/SKILL.md`: reword step 4's "the only exception" line to point at the
+- [x] 2.5 `skills/groom/SKILL.md`: reword step 4's "the only exception" line to point at the
       contract's list of exempt batches.
-- [ ] 2.6 `skills/setup/SKILL.md`: reference the contract alongside its existing interview-discipline
+- [x] 2.6 `skills/setup/SKILL.md`: reference the contract alongside its existing interview-discipline
       reference.
-- [ ] 2.7 `agents/project-manager.md`: add a compliant pointer to the contract for its owner-facing
+- [x] 2.7 `agents/project-manager.md`: add a compliant pointer to the contract for its owner-facing
       presentations (board, next-decision, archive confirmations).
 
 ## 3. Verification

--- a/openspec/changes/issue-82/tasks.md
+++ b/openspec/changes/issue-82/tasks.md
@@ -1,0 +1,40 @@
+# Tasks — issue 82: owner presentation contract
+
+## 1. The canonical contract
+
+- [ ] 1.1 Add a "Presenting to the owner" section to `docs/workflow.md` with the four rules: plain
+      terms before any identifier; one decision at a time by default; the owner may override to a
+      batch; every option states its cost and marks the recommended one where one exists.
+- [ ] 1.2 In that section, split the rules by kind: plain terms and translate-the-words apply to
+      every presentation including PR bodies and comments; one-at-a-time and its wait apply to
+      interactive decision points.
+- [ ] 1.3 In that section, name the deliberate batch presentations the contract does not govern:
+      status summaries (the board), read-only check batches (`setup` step 1), whole-artifact reviews
+      (Seam 1 coverage tables, `implement`'s residual findings list).
+
+## 2. Fix each owner-facing presenter in place
+
+- [ ] 2.1 `agents/issue-manager.md`: reword the 0.46.0 sentence to forbid an identifier only as
+      subject or sole referent, allow it as a trailing tag; add the panel-finding relay rule and the
+      one-at-a-time default to the relay path; reference the contract.
+- [ ] 2.2 `skills/implement/SKILL.md`: fix the fix-round and gate-failure emitting instructions so
+      residual findings are stated in plain terms with the identifier as a trailing tag; reference
+      the contract.
+- [ ] 2.3 `skills/address/SKILL.md`: fix the report path so findings are stated in plain terms;
+      reference the contract.
+- [ ] 2.4 `skills/activate/SKILL.md`: add the missing recommended-default half to step 1 ("with a
+      recommended answer where you have one"); reference the contract.
+- [ ] 2.5 `skills/groom/SKILL.md`: reword step 4's "the only exception" line to point at the
+      contract's list of exempt batches.
+- [ ] 2.6 `skills/setup/SKILL.md`: reference the contract alongside its existing interview-discipline
+      reference.
+- [ ] 2.7 `agents/project-manager.md`: add a compliant pointer to the contract for its owner-facing
+      presentations (board, next-decision, archive confirmations).
+
+## 3. Verification
+
+- [ ] 3.1 Write `verification.md` with a worked before/after example per acceptance criterion.
+- [ ] 3.2 Write the coverage checklist mapping each acceptance criterion to the file and line that
+      satisfies it.
+- [ ] 3.3 Scan every bound file and confirm no instruction tells an agent to present the owner a bare
+      identifier as a referent.

--- a/openspec/changes/issue-82/tasks.md
+++ b/openspec/changes/issue-82/tasks.md
@@ -33,8 +33,8 @@
 
 ## 3. Verification
 
-- [ ] 3.1 Write `verification.md` with a worked before/after example per acceptance criterion.
-- [ ] 3.2 Write the coverage checklist mapping each acceptance criterion to the file and line that
+- [x] 3.1 Write `verification.md` with a worked before/after example per acceptance criterion.
+- [x] 3.2 Write the coverage checklist mapping each acceptance criterion to the file and line that
       satisfies it.
-- [ ] 3.3 Scan every bound file and confirm no instruction tells an agent to present the owner a bare
+- [x] 3.3 Scan every bound file and confirm no instruction tells an agent to present the owner a bare
       identifier as a referent.

--- a/openspec/changes/issue-82/verification.md
+++ b/openspec/changes/issue-82/verification.md
@@ -52,3 +52,40 @@ crash the caller (F1)."
 
 The board still lists many issues at once. Seam 1 still renders the whole coverage table. A PR body
 still lists all residual findings. None of these is split into one item at a time.
+
+## Confirmation — the before/after examples still match the shipped prose
+
+The examples above are unchanged and still match what was written. AC1's "after" (the retry loop has
+no backoff, `C8`) matches `agents/issue-manager.md`'s relay example. AC5's "after" (one canonical
+block plus in-place fixes, recommended) matches this change's own design. No example diverged from
+the implementation, so none was adjusted.
+
+## Coverage checklist — each acceptance criterion to the file and line that satisfies it
+
+The canonical contract lives in `plugins/spec-flow/docs/workflow.md`, section "Presenting to the
+owner" (line 379). Each bound presenter references it and fixes its own emitting instruction in
+place.
+
+| AC | Requirement | Canonical rule | Bound emitting instruction(s) |
+|---|---|---|---|
+| AC1 | Plain terms before any identifier; identifier only as a trailing tag | `docs/workflow.md:389` (rule 1) | `agents/issue-manager.md:90` (0.46.0 sentence reworded); `skills/implement/SKILL.md:437`, `575`; `skills/address/SKILL.md:96` |
+| AC2 | One decision at a time by default, wait for an answer | `docs/workflow.md:397` (rule 2) | `agents/issue-manager.md:103` (relay path); `skills/activate/SKILL.md:165` (step 1) |
+| AC3 | The owner may override to a batch, for that request only | `docs/workflow.md:400` (rule 3) | `agents/issue-manager.md:103` (relay path); `agents/project-manager.md:324` |
+| AC4 | A cited location is described, not just named | `docs/workflow.md:396` (rule 1, last sentence) | `skills/address/SKILL.md:96` (name a thread/comment/test, say what it is) |
+| AC5 | Options state cost; recommended one marked, or left to the owner | `docs/workflow.md:403` (rule 4) | `skills/activate/SKILL.md:165` (recommended-default half); `agents/project-manager.md:324` |
+| AC6 | A relayed finding is translated, not repeated verbatim | `docs/workflow.md:389` (rule 1, translate clause) | `agents/issue-manager.md:99` (relay-a-review-panel-finding rule) |
+
+Rule split by kind: `docs/workflow.md:408`. Exempt deliberate batches: `docs/workflow.md:414`, with
+`groom`'s bulk confirm reconciled at `skills/groom/SKILL.md:189`, `setup`'s check batch noted at
+`skills/setup/SKILL.md:14`, and `implement`'s residual list marked exempt at
+`skills/implement/SKILL.md:575`. Every-presenter binding: `agents/issue-manager.md`,
+`skills/implement/SKILL.md`, `skills/address/SKILL.md`, `skills/activate/SKILL.md`,
+`skills/groom/SKILL.md`, `skills/setup/SKILL.md`, and `agents/project-manager.md`.
+
+## Scan — no bound file presents a bare identifier as a referent
+
+A scan of every bound file for identifier-as-referent phrasing (`should I fix C8`, `see C8`, `per
+A34`, `cite ... by its identifier`) found only two matches, both inside quoted negative examples in
+`agents/issue-manager.md` (line 91 "see C8"/"per A34" both fail; line 103 "should I fix `C8`?" shown
+as the wrong form). No instruction directs an agent to present the owner a bare identifier as a
+subject or sole referent.

--- a/openspec/changes/issue-82/verification.md
+++ b/openspec/changes/issue-82/verification.md
@@ -1,0 +1,54 @@
+# Verification — issue 82: worked before/after examples
+
+Prose has no unit test. Each acceptance criterion below shows a bad presentation and its compliant
+rewrite. These pairs are the definition of done: the contract is correct only if it produces the
+"after" in each case.
+
+## AC1 — plain terms before any identifier
+
+**Before:** "Should I fix C8 and SEC-3 before Build?"
+
+**After:** "The review found two things. The retry loop has no backoff, so it can hammer a failing
+service (C8). And the auth token is written to the log in plaintext (SEC-3). Want me to fix the
+logging one first?"
+
+## AC2 — one decision at a time
+
+**Before:** a single message listing five findings, each with options, all at once.
+
+**After:** the first finding and its options, then a wait for the owner's answer, then the second.
+
+## AC3 — the owner may override to a batch
+
+**Before:** the agent decides on its own to dump the whole set.
+
+**After:** the owner says "show me all five." The agent presents all five for that request, then
+returns to one-at-a-time for the next set without being asked again.
+
+## AC4 — a cited location is described
+
+**Before:** "See `reviewer.md:120`."
+
+**After:** "In `reviewer.md`, the lens is told to cite the rule or scenario for each finding (around
+line 120). That is the text we would change."
+
+## AC5 — options state cost, recommended one marked
+
+**Before:** "Option A, Option B, or Option C?"
+
+**After:** "Option A: one canonical block plus in-place fixes — most surface to touch, but no drift
+(recommended). Option B: restate in each file — no hop, but duplication drift. Option C: pointers
+only — cheapest, but likely will not change behavior."
+
+## AC6 — a relayed finding is translated
+
+**Before:** the lead repeats the lens's phrasing "F1: contract violation in the caller/callee
+boundary."
+
+**After:** "The review found the function returns null where the caller expects a value, which would
+crash the caller (F1)."
+
+## Boundary check — deliberate batches are not broken
+
+The board still lists many issues at once. Seam 1 still renders the whole coverage table. A PR body
+still lists all residual findings. None of these is split into one item at a time.

--- a/plugins/spec-flow/agents/issue-manager.md
+++ b/plugins/spec-flow/agents/issue-manager.md
@@ -87,11 +87,23 @@ you ask anything:
    findings — the state that led to this decision point.
 4. **The decision you need, and the options.** Exactly what you are asking, with the trade-offs.
 
-**Summarize; never cite a spec section by its identifier.** Do not tell the owner "see C8" or
-"per A34". They may not have the spec open, and a bare identifier carries no meaning. State the
-information itself — the requirement, the scenario, the constraint — in your own plain words. Read
-the spec, the issue, and the review findings yourself, then give the owner the substance, so they
-can decide without opening a single file.
+**Summarize; state the substance before any identifier.** Do not make an identifier the subject or
+the sole referent of what you say: "see C8" and "per A34" both fail, because the owner may not have
+the spec open and a bare identifier carries no meaning on its own. State the information itself — the
+requirement, the scenario, the constraint — in your own plain words first; a spec section identifier
+may then ride along as a trailing tag, never as the thing you point at. Read the spec, the issue, and
+the review findings yourself, then give the owner the substance, so they can decide without opening a
+single file. This is the **Presenting to the owner** contract in `docs/workflow.md`; follow it at
+every stop.
+
+**Relaying a review-panel finding.** The review lenses tag their findings with internal codes
+(`C8`, `SEC-3`, `F1`). Those codes mean something to the lens that emitted them and to nothing else.
+When you relay a finding to the owner, state the problem in plain terms — translate the lens's words,
+do not repeat them — and let the tag ride only as a trailing tag: "the retry loop has no backoff, so
+it can hammer a failing service (`C8`)", never "should I fix `C8`?". When a review round returns
+several findings the owner must decide on, present them one at a time by default, waiting for an
+answer before the next, per the contract; the owner may ask for the whole set at once, and that
+override applies to that request only.
 
 Keep the briefing tight; it is a reminder, not a re-read of the whole issue. Give enough context to
 decide, and no more.

--- a/plugins/spec-flow/agents/project-manager.md
+++ b/plugins/spec-flow/agents/project-manager.md
@@ -320,6 +320,14 @@ on the owner's behalf.
 
 ## Style
 
+- **Present to the owner by the contract.** Every owner-facing presentation you make — the next
+  decision, the archive batch to confirm, an option list — follows the **Presenting to the owner**
+  contract in `docs/workflow.md`: state the substance in plain terms before any identifier, one
+  decision at a time by default, each option with its cost and the recommended one marked. This
+  extends, and does not repeat, the rule above that you never translate the owner's autonomy words
+  into internal Seam vocabulary. The board and the archive batch are deliberate batch presentations
+  the contract names as exempt from the one-at-a-time rule; still state each item in them in plain
+  terms.
 - **Lead with the board, then a recommendation.** Tell the owner what's next and what's blocked on
   them in one tight picture, then propose the single next action — don't dump every option.
 - **Always write an issue or PR as `<number>: <title>`** — `85: Field identity in the sync path`,

--- a/plugins/spec-flow/docs/workflow.md
+++ b/plugins/spec-flow/docs/workflow.md
@@ -376,6 +376,53 @@ relationship renders directly in GitHub's own UI, not just in a comment. Additiv
 replacement — the label stays queryable (`gh issue list --label blocked`) in a way the native link
 alone isn't.
 
+## Presenting to the owner
+
+Every agent that brings the owner a finding, an option, or a decision follows this contract. It is
+the one place the rule is stated; each owner-facing presenter is bound to it and also fixes its own
+emitting instruction in place, so the rule bites at the point the text is written, not just at a
+pointer. This section is the canonical statement; the bound files point here rather than restating
+it.
+
+Four rules govern a presentation:
+
+1. **Plain terms come before any identifier.** State what is wrong, or what a section requires, in
+   plain words first. An internal identifier — a review-panel finding tag such as `C8` or `SEC-3`, a
+   spec section, or a task number — may appear only as a trailing tag. It is never the subject of the
+   sentence, and never the only referent. "Should I fix `SEC-3`?" is wrong; "the auth token is
+   written to the log in plaintext (`SEC-3`)" is right. When an agent relays a finding it did not
+   author, it translates the author's words into plain terms; it does not repeat the author's
+   vocabulary unchanged. When it cites a file, a line, a scenario, or a task, it says what is there;
+   it does not assume the owner has the artifact open.
+2. **One decision at a time, by default.** When an agent has several findings or decisions, it
+   presents the first, waits for the owner's answer, then presents the next. It does not send the
+   whole set in one message.
+3. **The owner may override to a batch.** The owner may ask for the whole set at once; the agent then
+   presents them together. That override applies to that one request only. The agent returns to one
+   at a time for the next set, without being told again.
+4. **Each option states its cost, and the recommended one is marked.** When an agent lists options,
+   each option states what it costs as well as what it does. The agent marks the recommended option
+   where it has a recommendation. Where the choice is deliberately the owner's and the agent
+   withholds a recommendation, it leaves the options unmarked and says the choice is the owner's.
+
+**The rules split by kind of presentation.** Rule 1 — plain terms, the trailing-tag limit, and
+translating a relayed finding's words — applies to every presentation, whether it is a live turn or
+text written into an artifact such as a PR body or an issue comment. Rule 2 — one at a time, and the
+wait for an answer — applies to interactive decision points only, where the owner answers before the
+next. A one-shot written artifact is not split into separate writes with waits between them.
+
+**Deliberate batch presentations are not governed by rule 2.** Some presentations are meant to show
+many items at once, and the contract does not force them into one item at a time:
+
+- status summaries — the board, which renders many issues together;
+- read-only check batches — `setup` step 1, which runs its checks in parallel and reports them as a
+  set;
+- whole-artifact reviews — Seam 1's `ac-coverage.md`/`overrides.md` tables, and `implement`'s
+  residual findings list written into a PR body.
+
+These still follow rule 1: each item in them is stated in plain terms, with any identifier as a
+trailing tag.
+
 ## Lifecycle and labels
 
 ```

--- a/plugins/spec-flow/skills/activate/SKILL.md
+++ b/plugins/spec-flow/skills/activate/SKILL.md
@@ -162,9 +162,11 @@ qualify), and confirm the choice with the owner.
    duplicate, or a dependency, or just coincidentally similar; anything that's changed since this
    was filed that the acceptance criteria doesn't capture.
 
-   Ask them **one at a time** — never dump the whole list on the owner at once — and follow up on
+   Ask them **one at a time, with a recommended answer where you have one** — never dump the whole
+   list on the owner at once — and follow up on
    whatever the answer actually raises rather than moving mechanically to the next scripted
-   question. If the owner confirms a backlog hit is a genuine hard dependency, handle it exactly like
+   question. This is the **Presenting to the owner** contract in `docs/workflow.md`: one decision at
+   a time, and a marked recommendation where you have one. If the owner confirms a backlog hit is a genuine hard dependency, handle it exactly like
    the architect-flagged case at step 4 below (`blocked` label + native GitHub issue dependency +
    comment) — don't invent a second mechanism for the same fact. If an answer changes the scope or
    acceptance criteria, update the issue body before continuing so the change is durable, not just

--- a/plugins/spec-flow/skills/address/SKILL.md
+++ b/plugins/spec-flow/skills/address/SKILL.md
@@ -93,7 +93,10 @@ by branch name: `gh pr list --search "Closes #<N> in:body" --json number,headRef
    gh issue edit <N> --remove-label status:addressing --add-label status:in-review
    gh issue comment <N> --body "🔧 Addressed <N-comments> review comment(s), pushed \`<short-sha>\`."
    ```
-   Report what changed and the PR URL. The owner re-reviews; loop `/spec-flow:address` again if they
+   Report what changed and the PR URL. State what changed and what is still broken in plain terms;
+   if you name a review thread, a comment, or a test, say what it is, and let any identifier ride as
+   a trailing tag only — the **Presenting to the owner** contract in `docs/workflow.md`. The owner
+   re-reviews; loop `/spec-flow:address` again if they
    leave more comments, or they squash-merge and you run `/spec-flow:finalize <N>`.
 
 ## Rules

--- a/plugins/spec-flow/skills/groom/SKILL.md
+++ b/plugins/spec-flow/skills/groom/SKILL.md
@@ -187,7 +187,9 @@ refines. Stay in the foreground — no worktrees, no implementation.
      owner wrote, and the moment of least attention is the wrong moment to grant that.
 
    This bulk confirmation is a **deliberate, scoped exception** to the one-question-at-a-time rule
-   above, and the only one. It applies to the traceable group at the closing pass, nowhere else:
+   above — one of the deliberate batch presentations the **Presenting to the owner** contract in
+   `docs/workflow.md` names as exempt, not a rule unique to `groom`. It applies to the traceable
+   group at the closing pass, nowhere else:
    the loop's questions each shape the work, while these are already-stated positions being
    confirmed as a set at the end.
 

--- a/plugins/spec-flow/skills/implement/SKILL.md
+++ b/plugins/spec-flow/skills/implement/SKILL.md
@@ -434,7 +434,9 @@ path never generates one (see step 4's tech-debt handling); otherwise, list `ope
       missing** — reachable when a lens declines over something this repo's gate does not treat as
       must-fix — **stop the loop**: another round has the same inputs and produces the same verdict,
       and a fix teammate would be handed an empty list. Take step 5's gate failure path and tell the
-      owner a lens declined on a non-blocking finding, so it needs their call. **If any implementer's report contains
+      owner a lens declined on a non-blocking finding, so it needs their call. State that finding in
+      plain terms, with the lens identifier as a trailing tag only — the **Presenting to the owner**
+      contract in `docs/workflow.md`, the same as every finding you relay. **If any implementer's report contains
       `SPEC-DEFECT:`, stop the loop immediately** — the approved spec is what's wrong, more rounds
       cannot fix it (the one change that would resolve the finding is the one GUARDRAILS forbids),
       and only the owner can change it. Take step 5's gate failure path with that report as the
@@ -568,7 +570,11 @@ path never generates one (see step 4's tech-debt handling); otherwise, list `ope
    `agent:active` and `status:in-progress` as they are, and stop. **If a PR exists**, also leave it
    a draft and write the residual findings into its body. **If none exists** — a fast-path run that
    halted before its PR was ever opened, which is exactly what question 4 catches — put the
-   residual findings in that issue comment instead; it is the only place they can land. Never mark a red or unapproved PR ready, and never
+   residual findings in that issue comment instead; it is the only place they can land. Wherever
+   they land, state each residual finding in plain terms, with the lens identifier as a trailing tag
+   only, never as the finding's sole referent — the **Presenting to the owner** contract in
+   `docs/workflow.md`. The residual list itself is a whole-artifact review, which that contract
+   names as exempt from the one-at-a-time rule; write it as one block. Never mark a red or unapproved PR ready, and never
    merge one, whatever `merge-on-green` or the issue's owner instructions say. Those authorize
    crossing Seam 2 on a *finished* run; they do not authorize skipping the panel.
 

--- a/plugins/spec-flow/skills/setup/SKILL.md
+++ b/plugins/spec-flow/skills/setup/SKILL.md
@@ -11,8 +11,10 @@ worktree). Turn the README's **Prerequisites** checklist from something the owne
 self-diagnoses into something you actually walk them through: explore what's already true, then
 only ask about what isn't — each item with your own recommended action stated up front, so the
 owner can accept in one word. Same interview discipline `groom` uses for scope (see its steps 1
-and 4): one question at a time, recommended default alongside it, ordered so an earlier answer can
-make a later question moot.
+and 4), and the **Presenting to the owner** contract in `docs/workflow.md`: one question at a time,
+recommended default alongside it, ordered so an earlier answer can
+make a later question moot. Step 1's read-only checks run as a batch, which that contract names as
+exempt from the one-at-a-time rule.
 
 ## Steps
 


### PR DESCRIPTION
Closes #82

## What this changes

Agents used to present review findings by their internal identifier (`C8`, `SEC-3`, `F1`) as if the owner shared that vocabulary, and to ask several questions at once. This change adds one presentation contract that binds every owner-facing presenter, so all skills present findings and decisions the same way.

The contract lives in `docs/workflow.md`, section "Presenting to the owner". Four rules:

1. State a finding in plain terms first; an identifier is a trailing tag only, never the subject or sole referent. A relayed finding is translated, not repeated in the author's words.
2. Present decisions one at a time by default, and wait for the owner's answer before the next.
3. The owner may override to a batch; the override applies to that request only.
4. Each option states its cost as well as its effect, and the recommended one is marked, except where the choice is deliberately the owner's.

A cited file, line, scenario, or task number says what is there, not just names it. Plain terms apply to written artifacts too (PR bodies, comments); one-at-a-time applies to live decision points. Deliberate batches are exempt and named: the board, read-only check batches, whole-artifact reviews, and groom's bulk assumption confirm.

## How

Each rule points at the contract, and every emitting instruction is also fixed in place, not just pointed at the contract. Bound presenters: `issue-manager`, `implement`, `address`, `activate`, `groom`, `setup`, `project-manager`. The 0.46.0 sentence in `issue-manager.md` is reworded to allow a trailing tag rather than ban every identifier. Review subagents that return to a relayer are not bound, since they never present to the owner.

## Tests

Per `spec-flow/TESTING.md`, this change touches markdown plus one JSON manifest. The applicable gate is the manifest parse check, which passed (`python3 -m json.tool` on `plugin.json`: JSON_OK). No shell or Python files were touched, so no other gate applies. Prose has no unit test; `verification.md` in the change holds a worked before/after example per acceptance criterion as the definition of done.

## Review

The five-lens panel (spec, correctness, security, test-rigor, observability) approved with no blocking or major findings. One minor consistency finding was fixed (groom's exempt-batch pointer now resolves). One low finding (drifted line numbers in an internal verification artifact) is left for owner triage.

## Version

spec-flow bumped 0.46.0 to 0.47.0.
